### PR TITLE
Fix encoding shift_jis CustomerName only

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
   "dependencies": {
     "axios": "0.16.2",
     "deepmerge": "^1.5.2",
-    "qs": "^6.6.0",
-    "qs-iconv": "^1.0.4"
+    "encoding-japanese": "^1.0.29",
+    "qs": "^6.6.0"
   },
   "devDependencies": {
     "@types/deepmerge": "^1.3.2",
+    "@types/encoding-japanese": "^1.0.15",
     "@types/node": "^8.0.32",
     "@types/qs": "^6.5.1",
     "ava": "^1.2.1",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,14 +1,13 @@
 import {AxiosInstance, AxiosResponse} from 'axios'
 import {BadRequest} from './errors'
 import * as qs from 'qs'
-const encoder = require('qs-iconv/encoder')('shift_jis')
 
 export default class Client {
   public client: AxiosInstance
   public options: object = {}
 
   public async post(endpoint: string, data: any): Promise<any> {
-    const res: AxiosResponse = await this.client.post(endpoint, qs.stringify(data, { encoder }), this.options)
+    const res: AxiosResponse = await this.client.post(endpoint, qs.stringify(data, { encode: false }), this.options)
     const parsed: any = qs.parse(res.data)
 
     if (this.isError(parsed)) {

--- a/src/client/cvsTranable.ts
+++ b/src/client/cvsTranable.ts
@@ -1,4 +1,5 @@
 import {AxiosInstance} from 'axios'
+import * as encoding from 'encoding-japanese'
 import * as merge from 'deepmerge'
 import Client from '../client'
 import {IConfig} from '../config.interface'
@@ -30,7 +31,11 @@ export default class CvsTranable extends Client {
   }
 
   public async execTranCvs(args: IExecTranCvsArgs): Promise<IExecTranCvsResult> {
-    const parsed: any = await this.post('/payment/ExecTranCvs.idPass', args)
+    const parsed: any = await this.post('/payment/ExecTranCvs.idPass', {
+      ...args,
+      CustomerName: encoding.urlEncode(encoding.convert(args.CustomerName, 'SJIS')),
+      CustomerKana: encoding.urlEncode(encoding.convert(args.CustomerKana, 'SJIS'))
+    })
 
     return <IExecTranCvsResult> parsed
   }


### PR DESCRIPTION
I also got similar problem with this PR #9.
The problem is caused that `qs-iconv module` returns empty string when a field type `number` and a field value `0`.
```ts
interface IExecTranArgs {
  ...
  CardSeq?: number
  ...
}

const execTranArgs = {
  ...
  // In this case, iconv-lite(used by qs-iconv) encode method returns a empty buffer list..
  // So it will be changed to empty string.
  CardSeq: 0,
  ...
}

const execTranArgs = {
  ...
  // In this case, iconv-lite(used by qs-iconv) encode method returns a buffer list includes a value 48 (decimal value of char '0').
  // So it will be changed to string '0'.
  CardSeq: '0',
  ...
}
```

I checked the PR #9. Separating method to `post` and `postWithEncodeShiftJIS` is also good this solution. But I worry to face with a same problem I mentioned above when I use a method `postWithEncodeShiftJIS`.

In my opinion, post body does not need to encode fields to shift_jis because usually fields have alphanumeric values, and if some of fields need to encode to shift_jis such as `CustomerName` then it should be encoded before calling post method.

Please check my approach.