### PR TITLE
Add cancellation of CVS transaction API

### DIFF
--- a/src/client/cvsTranable.interface.ts
+++ b/src/client/cvsTranable.interface.ts
@@ -1,4 +1,4 @@
-import {CvsCode} from '../client.enum'
+import {CvsCode, Status} from '../client.enum'
 import {IResult, IShopArgs} from '../client.interface'
 
 export interface IEntryTranCvsArgs extends IShopArgs {
@@ -63,4 +63,15 @@ export interface IExecTranCvsResult extends IResult {
   ClientField1: string
   ClientField2: string
   ClientField3: string
+}
+
+export interface ICancelCvsArgs extends IShopArgs {
+  AccessID: string
+  AccessPass: string
+  OrderID: string
+}
+
+export interface ICancelCvsResult extends IResult {
+  OrderID: string
+  Status: Status
 }

--- a/src/client/cvsTranable.test.ts
+++ b/src/client/cvsTranable.test.ts
@@ -1,8 +1,9 @@
 import anyTest, {TestInterface} from 'ava'
 import Axios, {AxiosRequestConfig, AxiosResponse} from 'axios'
-import {CvsCode} from '../client.enum'
+import {CvsCode, Status} from '../client.enum'
 import CvsTranable from './cvsTranable'
 import {
+  ICancelCvsResult,
   IEntryTranCvsResult,
   IExecTranCvsResult
 } from './cvsTranable.interface'
@@ -102,3 +103,37 @@ test('.execTranCvs calls API and returns response', async (t) => {
   t.deepEqual(res, expect)
 })
 
+test('.cancelCvs calls API and returns response', async (t) => {
+  t.context.cvsTran.options = {
+    adapter: async (config: AxiosRequestConfig) => {
+      const text = [
+        'OrderID=orderid',
+        `Status=${Status.Cancel}`
+      ].join('&')
+      const response: AxiosResponse = {
+        data: text,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config
+      }
+
+      return Promise.resolve(response)
+    }
+  }
+
+  const args = {
+    ShopID: 'shopid',
+    ShopPass: 'shoppass',
+    AccessID: 'accessid',
+    AccessPass: 'accesspass',
+    OrderID: 'orderid'
+  }
+  const res = await t.context.cvsTran.cancelCvs(args)
+
+  const expect: ICancelCvsResult = {
+    OrderID: 'orderid',
+    Status: Status.Cancel
+  }
+  t.deepEqual(res, expect)
+})

--- a/src/client/cvsTranable.ts
+++ b/src/client/cvsTranable.ts
@@ -4,6 +4,8 @@ import * as merge from 'deepmerge'
 import Client from '../client'
 import {IConfig} from '../config.interface'
 import {
+  ICancelCvsArgs,
+  ICancelCvsResult,
   IEntryTranCvsArgs,
   IEntryTranCvsResult,
   IExecTranCvsArgs,
@@ -40,4 +42,17 @@ export default class CvsTranable extends Client {
     return <IExecTranCvsResult> parsed
   }
 
+  public async cancelCvs(args: ICancelCvsArgs): Promise<ICancelCvsResult> {
+    const defaultData = {
+      ShopID: this.config !== undefined ? this.config.ShopID : undefined,
+      ShopPass: this.config !== undefined ? this.config.ShopPass : undefined,
+      AccessID: undefined,
+      AccessPass: undefined,
+      OrderID: undefined
+    }
+    const data: ICancelCvsArgs = merge(defaultData, args)
+    const parsed: any = await this.post('/payment/CvsCancel.idPass', data)
+
+    return <ICancelCvsResult> parsed
+  }
 }

--- a/src/client/tranable.interface.ts
+++ b/src/client/tranable.interface.ts
@@ -1,4 +1,4 @@
-import {JobCd, Method, SeqMode} from '../client.enum'
+import {JobCd, Method, SeqMode, Status} from '../client.enum'
 import {IResult, IShopArgs} from '../client.interface'
 
 export interface IEntryTranArgs extends IShopArgs {
@@ -76,7 +76,7 @@ export interface ISearchTradeArgs extends IShopArgs {
 
 export interface ISearchTradeResult extends IResult {
   OrderID: string
-  Status: string
+  Status: Status
   ProcessDate: string
   JobCd: JobCd
   AccessID: string

--- a/src/client/tranable.test.ts
+++ b/src/client/tranable.test.ts
@@ -1,6 +1,6 @@
 import anyTest, {TestInterface} from 'ava'
 import Axios, {AxiosRequestConfig, AxiosResponse} from 'axios'
-import {JobCd, Method} from '../client.enum'
+import {JobCd, Method, Status} from '../client.enum'
 import Tranable from './tranable'
 import {
   IAlterTranResult,
@@ -154,7 +154,7 @@ test('.searchTrade calls API and returns response', async (t) => {
     adapter: async (config: AxiosRequestConfig) => {
       const text = [
         'OrderID=orderid',
-        'Status=status',
+        'Status=CHECK',
         'ProcessDate=processdate',
         'JobCd=CHECK',
         'AccessID=accessid',
@@ -196,7 +196,7 @@ test('.searchTrade calls API and returns response', async (t) => {
 
   const expect: ISearchTradeResult = {
     OrderID: 'orderid',
-    Status: 'status',
+    Status: Status.Check,
     ProcessDate: 'processdate',
     JobCd: JobCd.Check,
     AccessID: 'accessid',

--- a/src/gmopg.test.ts
+++ b/src/gmopg.test.ts
@@ -119,6 +119,10 @@ test('.execTranCvs is function', (t) => {
   t.is(typeof t.context.gmopg.execTranCvs, 'function')
 })
 
+test('.cancelCvs is function', (t) => {
+  t.is(typeof t.context.gmopg.cancelCvs, 'function')
+})
+
 test('.searchTradeMulti is function', (t) => {
   t.is(typeof t.context.gmopg.searchTradeMulti, 'function')
 })

--- a/src/gmopg.ts
+++ b/src/gmopg.ts
@@ -40,6 +40,8 @@ import {
   ISearchTradeResult
 } from './client/tranable.interface'
 import {
+  ICancelCvsArgs,
+  ICancelCvsResult,
   IEntryTranCvsArgs,
   IEntryTranCvsResult,
   IExecTranCvsArgs,
@@ -84,6 +86,7 @@ export class GMOPG implements Memberable, Cardable, Tranable, CvsTranable, Multi
   // tranable - cvs
   public entryTranCvs: (args: IEntryTranCvsArgs) => Promise<IEntryTranCvsResult>
   public execTranCvs: (args: IExecTranCvsArgs) => Promise<IExecTranCvsResult>
+  public cancelCvs: (args: ICancelCvsArgs) => Promise<ICancelCvsResult>
 
   // tranable - multi
   public searchTradeMulti: <R extends ISearchTradeMultiCardResult | ISearchTradeMultiCvsResult>(args: ISearchTradeMultiArgs) => Promise<R>


### PR DESCRIPTION
I added cancellation of CVS transaction API.
- CvsCancel.idPass
It is working when a transaction of CVS has a `REQSUCCESS` status.

Additionally, I changed the type of `Status`property in `ISearchTradeResult` to `Status` enum.

Please check it. Thank you.