### PR TITLE
add searchCardDetail

### DIFF
--- a/src/client/cardable.interface.ts
+++ b/src/client/cardable.interface.ts
@@ -1,5 +1,5 @@
 import {SeqMode} from '../client.enum'
-import {IResult, ISiteArgs} from '../client.interface'
+import {IResult, ISiteArgs, IShopArgs} from '../client.interface'
 
 export interface ISaveCardArgs extends ISiteArgs {
   SeqMode?: SeqMode
@@ -47,6 +47,25 @@ export interface ISearchCardResult extends IResult {
   Expire: string
   HolderName: string
   DeleteFlag: string
+  Brand?: string
+  DomesticFlag?: string
+  IssuerCode?: string
+  DebitPrepaidFlag?: string
+  DebitPrepaidIssuerName?: string
+  ForwardFinal?: string
+}
+
+export interface ISearchCardDetailArgs extends IShopArgs, ISiteArgs {
+  Token?: string
+  SearchType?: string
+  CardNo?: string
+  OrderID?: string
+  SeqMode?: SeqMode
+  CardSeq?: string
+}
+
+export interface ISearchCardDetailResult extends IResult {
+  CardNo?: string
   Brand?: string
   DomesticFlag?: string
   IssuerCode?: string

--- a/src/client/cardable.test.ts
+++ b/src/client/cardable.test.ts
@@ -3,7 +3,7 @@ import sinon = require('sinon')
 import Client from '../client'
 import {SeqMode} from '../client.enum'
 import WithCardable from './cardable'
-import {IDeleteCardResult, ISaveCardResult, ISearchCardResult} from './cardable.interface'
+import {IDeleteCardResult, ISaveCardResult, ISearchCardResult, ISearchCardDetailResult, ISearchCardDetailArgs} from './cardable.interface'
 
 const Cardable = WithCardable(Client)
 const cardable = new Cardable()
@@ -76,6 +76,34 @@ test('.searchCard calls API and returns response', async (t) => {
     CardSeq: 'cardseq'
   }
   const res = await cardable.searchCard(args)
+
+  t.deepEqual(res, expect)
+})
+
+test('.searchCardDetail calls API and returns response', async (t) => {
+
+  const result: ISearchCardDetailResult = {
+    CardNo: 'cardno',
+    Brand: 'brand',
+    DomesticFlag: '1',
+    IssuerCode: '1234567',
+    DebitPrepaidFlag: '1',
+    DebitPrepaidIssuerName: 'debitPrepaidIssuerName',
+    ForwardFinal: '1234567',
+    ErrCode: '',
+    ErrInfo: '',
+  }
+
+  sinon.stub(cardable, 'post').resolves(result)
+
+  const expect = [result]
+
+  const args: ISearchCardDetailArgs = {
+    ShopID: 'shopid',
+    ShopPass: 'shoppass',
+    Token: 'token'
+  }
+  const res = await cardable.searchCardDetail(args)
 
   t.deepEqual(res, expect)
 })

--- a/src/client/cardable.ts
+++ b/src/client/cardable.ts
@@ -7,7 +7,9 @@ import {
   ISaveCardArgs,
   ISaveCardResult,
   ISearchCardArgs,
-  ISearchCardResult
+  ISearchCardResult,
+  ISearchCardDetailArgs,
+  ISearchCardDetailResult
 } from './cardable.interface'
 
 export default <T extends Constructor<Client>>(Base: T) => class Cardable extends Base {
@@ -59,4 +61,34 @@ export default <T extends Constructor<Client>>(Base: T) => class Cardable extend
       }
     })
   }
+
+  public async searchCardDetail(args: ISearchCardDetailArgs): Promise<ISearchCardDetailResult[]> {
+    const data: ISearchCardDetailArgs = merge(this.defaultCardData(), args)
+    const parsed: any = await this.post('/payment/SearchCardDetail.idPass', data)
+
+    const cardNoArry: string[] = parsed.CardNo.split('|')
+    const brandArry: string[] = parsed.Brand.split('|')
+    const domesticFlagArry: string[] = parsed.DomesticFlag.split('|')
+    const issuerCodeArry: string[] = parsed.IssuerCode.split('|')
+    const debitPrepaidFlagArry: string[] = parsed.DebitPrepaidFlag.split('|')
+    const debitPrepaidIssuerNameArry: string[] = parsed.DebitPrepaidIssuerName.split('|')
+    const forwardFianlArry: string[] = parsed.ForwardFinal.split('|')
+    const errCodeArry: string[] = parsed.ErrCode.split('|')
+    const errInfoArry: string[] = parsed.ErrInfo.split('|')
+
+    return cardNoArry.map((_, index): ISearchCardDetailResult => {
+      return {
+        CardNo: cardNoArry[index],
+        Brand: brandArry[index],
+        DomesticFlag: domesticFlagArry[index],
+        IssuerCode: issuerCodeArry[index],
+        DebitPrepaidFlag: debitPrepaidFlagArry[index],
+        DebitPrepaidIssuerName: debitPrepaidIssuerNameArry[index],
+        ForwardFinal: forwardFianlArry[index],
+        ErrCode: errCodeArry[index],
+        ErrInfo: errInfoArry[index]
+      }
+    })
+  }
+
 }


### PR DESCRIPTION
Hi, I've added an implementation for `/payment/SearchCardDetail.idPass`, which is specified in the spec(`カード決済 インタフェース仕様`) section `2.19.2.1.`.

Although I've paid good amount of attention to follow the spec, there may be some things that I'm misunderstanding so I'd like to have this reviewed. 

Thank you in advance!