### PR TITLE
dedupe errInfo codes, update node version and ts target

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript": "^3.6.3"
   },
   "engines": {
-    "node": ">=8.4.0"
+    "node": ">=10"
   },
   "ava": {
     "compileEnhancements": false,

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -18,3 +18,9 @@ test('.parseError returns ErrInfo as array', (t) => {
   t.is(err.errInfo[0], 'NC1000009')
   t.is(err.errInfo[1], 'N0C030G96')
 })
+
+test('.parseError returns unique ErrInfos', (t) => {
+  const err = new BadRequest().parseError({ErrInfo: 'E61030001|E61030001'})
+  t.deepEqual(err.errors, [{ja: 'ご契約内容エラー/現在のご契約では、ご利用になれません。', en: 'Your request cannot be accepted under the current merchant contract.'}])
+  t.deepEqual(err.errInfo, ['E61030001'])
+})

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -23,7 +23,7 @@ export class BadRequest extends Error {
   }
 
   public parseError(obj: any): BadRequest {
-    this.errInfo = obj.ErrInfo.split('|')
+    this.errInfo = [...new Set<string>(obj.ErrInfo.split('|'))]
     this.errors = this.errInfo.map((code) => errorDefinition[code])
     return this
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2018",
     "module": "commonjs",
     "moduleResolution": "node",
     "allowUnreachableCode": false,


### PR DESCRIPTION
Nothing urgent but I've received this kind of errors in my logs: `errInfo: [ 'E61030001', 'E61030001' ]`

Should we have unique errInfo codes? this PR would deduplicate errInfos

Or maybe the fact the error is multiple times is important, I don't know yet

You can leave this PR pending for a while, I'm experimenting this idea in my own code first