### PR TITLE
Fix qs.parse without decoding

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -52,3 +52,17 @@ test('.post returns errors correctly', async (t) => {
     t.deepEqual(err.errInfo, ["E01190001"])
   }
 })
+
+test('.post should not decode "+" chars', async (t) => {
+  nock(baseUrl)
+    .post(/.*/)
+    .reply(200, 'TranID=123aZ&Token=abc123/+-_&StartUrl=https://x.y/z')
+
+  const res = await client.post('/test1', {foo: '1'});
+
+  t.deepEqual(res, {
+    TranID: '123aZ',
+    Token: 'abc123/+-_',
+    StartUrl: 'https://x.y/z',
+  })
+})

--- a/src/client.ts
+++ b/src/client.ts
@@ -20,7 +20,7 @@ export default class Client {
       ...this.config.http,
     })
 
-    const parsed: any = qs.parse(await res.text());
+    const parsed: any = qs.parse(await res.text(), {decoder: decodeURIComponent});
 
     if (!res.ok || this.isError(parsed)) {
       throw new BadRequest(`Bad Request: ${pathname}`).


### PR DESCRIPTION
We've had issues with the way src/client parse responses

we use this call

```js
 const r = await gmopg.post('/payment/BankAccountEntry.idPass', {
      SiteID: gmopg.config.SiteID,
      SitePass: gmopg.config.SitePass,
      MemberID,
      MemberName: user.name,
      CreateMember: 1,
      ConsumerDevice: 'pc',
      ...otherParams
    });
```
in response, we could get for example:


```
{
  TranID: '607b45e7fbf9f6c72f17cd830caa7bb7e681eefd',
  Token: 'VI0PUD4zy1PCXk1ly830Avwi1YOelfRweXnRkh8SbgtzxIUg9Z4eWnw hJoODCFsCiSnnEV1crp7SKYSKKZUs0nX2cm1WH0xVIK63lktOl8_'
  // ...
}
```
There's a space in the middle of Token, but it should be a '+'.

It's because we're calling `qs.parse(response)` and the default decoder will transform '+' chars https://github.com/ljharb/qs/blob/master/lib/utils.js#L110

This commit fixes this issue, I hope it's compatible with everything else @linyows ?