### PR TITLE
Revert to initial errors list

### DIFF
--- a/error-codes.json
+++ b/error-codes.json
@@ -1,6854 +1,1690 @@
 {
-  "42C010000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C030000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C120000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C130000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C140000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C150000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C500000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C510000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C530000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C540000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C550000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C560000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C570000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C580000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C600000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C700000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C710000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C720000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C730000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C740000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C750000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C760000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C770000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42C780000": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "42G020000": {
-    "ja": "カード残高が不足しているために、決済を完了する事ができませんでした。",
-    "en": "Insufficient card balance"
-  },
-  "42G030000": {
-    "ja": "カード限度額を超えているために、決済を完了する事ができませんでした。",
-    "en": "The card limit has been exceeded"
-  },
-  "42G040000": {
-    "ja": "カード残高が不足しているために、決済を完了する事ができませんでした。",
-    "en": "Insufficient card balance"
-  },
-  "42G050000": {
-    "ja": "カード限度額を超えているために、決済を完了する事ができませんでした。",
-    "en": "The card limit has been exceeded"
-  },
-  "42G060000": {
-    "ja": "デビットカードで口座の残高が不足しています。",
-    "en": "Insufficient card balance"
-  },
-  "42G070000": {
-    "ja": "カード限度額を超えているために、決済を完了する事ができませんでした。",
-    "en": "The card limit has been exceeded"
-  },
-  "42G120000": {
-    "ja": "このカードでは取引をする事ができません。",
-    "en": "Invalid card"
-  },
-  "42G220000": {
-    "ja": "このカードでは取引をする事ができません。",
-    "en": "Invalid card"
-  },
-  "42G300000": {
-    "ja": "このカードでは取引をする事ができません。",
-    "en": "Invalid card"
-  },
-  "42G420000": {
-    "ja": "暗証番号が誤っていた為に、決済を完了する事ができませんでした。",
-    "en": "Wrong password"
-  },
-  "42G440000": {
-    "ja": "セキュリティーコードが誤っていた為に、決済を完了する事ができませんでした。",
-    "en": "Wrong security code"
-  },
-  "42G450000": {
-    "ja": "セキュリティーコードが入力されていない為に、決済を完了する事ができませんでした。",
-    "en": "Security code is not entered"
-  },
-  "42G540000": {
-    "ja": "このカードでは取引をする事ができません。",
-    "en": "Invalid card"
-  },
-  "42G550000": {
-    "ja": "カード限度額を超えているために、決済を完了する事ができませんでした。",
-    "en": "The card limit has been exceeded"
-  },
-  "42G560000": {
-    "ja": "このカードでは取引をする事ができません。",
-    "en": "Invalid card"
-  },
-  "42G600000": {
-    "ja": "このカードでは取引をする事ができません。",
-    "en": "Invalid card"
-  },
-  "42G610000": {
-    "ja": "このカードでは取引をする事ができません。",
-    "en": "Invalid card"
-  },
-  "42G650000": {
-    "ja": "カード番号に誤りがあるために、決済を完了する事ができませんでした。",
-    "en": "Wrong card number"
-  },
-  "42G670000": {
-    "ja": "商品コードに誤りがあるために、決済を完了する事ができませんでした。",
-    "en": "Wrong ItemCode"
-  },
-  "42G680000": {
-    "ja": "金額に誤りがあるために、決済を完了する事ができませんでした。",
-    "en": "Wrong value is set for \"Amount\""
-  },
-  "42G690000": {
-    "ja": "税送料に誤りがあるために、決済を完了する事ができませんでした。",
-    "en": "Wrong value is set for \"Tax\""
-  },
-  "42G700000": {
-    "ja": "ボーナス回数に誤りがあるために、決済を完了する事ができませんでした。",
-    "en": "Wrong value is set for \"Bonus Payment Times\""
-  },
-  "42G710000": {
-    "ja": "ボーナス月に誤りがあるために、決済を完了する事ができませんでした。",
-    "en": "Wrong value is set for \"Bonus Payment Month\""
-  },
-  "42G720000": {
-    "ja": "ボーナス額に誤りがあるために、決済を完了する事ができませんでした。",
-    "en": "Wrong value is set for \"Bonus Payment Amount\""
-  },
-  "42G730000": {
-    "ja": "支払開始月に誤りがあるために、決済を完了する事ができませんでした。",
-    "en": "Wrong value is set for \"1st month for payment\""
-  },
-  "42G740000": {
-    "ja": "分割回数に誤りがあるために、決済を完了する事ができませんでした。",
-    "en": "Wrong value is set for \"PayTimes\""
-  },
-  "42G750000": {
-    "ja": "分割金額に誤りがあるために、決済を完了する事ができませんでした。",
-    "en": "Wrong value is set for \"Payment Amount for Installment\""
-  },
-  "42G760000": {
-    "ja": "初回金額に誤りがあるために、決済を完了する事ができませんでした。",
-    "en": "Wrong value is set for the initial payment amount."
-  },
-  "42G770000": {
-    "ja": "業務区分に誤りがあるために、決済を完了する事ができませんでした。",
-    "en": "Wrong value is set for processing type"
-  },
-  "42G780000": {
-    "ja": "支払区分に誤りがあるために、決済を完了する事ができませんでした。",
-    "en": "Wrong value is set for payment type"
-  },
-  "42G790000": {
-    "ja": "照会区分に誤りがあるために、決済を完了する事ができませんでした。",
-    "en": "Wrong value is set for reference type"
-  },
-  "42G800000": {
-    "ja": "取消区分に誤りがあるために、決済を完了する事ができませんでした。",
-    "en": "Wrong value is set for cancellation type"
-  },
-  "42G810000": {
-    "ja": "取消取扱区分に誤りがあるために、決済を完了する事ができませんでした。",
-    "en": "Wrong value is set for cancellation type"
-  },
-  "42G830000": {
-    "ja": "有効期限に誤りがあるために、決済を完了する事ができませんでした。",
-    "en": "Wrong Expiry Month"
-  },
-  "42G920000": {
-    "ja": "このカードでは取引をする事ができません。",
-    "en": "Invalid card"
-  },
-  "42G950000": {
-    "ja": "このカードでは取引をする事ができません。",
-    "en": "Invalid card"
-  },
-  "42G960000": {
-    "ja": "このカードでは取引をする事ができません。",
-    "en": "Invalid card"
-  },
-  "42G970000": {
-    "ja": "このカードでは取引をする事ができません。",
-    "en": "Invalid card"
-  },
-  "42G980000": {
-    "ja": "このカードでは取引をする事ができません。",
-    "en": "Invalid card"
-  },
-  "42G990000": {
-    "ja": "このカードでは取引をする事ができません。",
-    "en": "Invalid card"
-  },
-  "AC2000001": {
-    "ja": "システムエラー /請求受付失敗",
-    "en": "System error/ Invoice not received correctly"
-  },
-  "AC2000002": {
-    "ja": "システムエラー /請求締切失敗",
-    "en": "System error/ Invoice deadline error"
-  },
-  "AC2000003": {
-    "ja": "システムエラー /請求結果反映失敗",
-    "en": "System error/ Invoice result display error"
-  },
-  "AC2000004": {
-    "ja": "システムエラー /請求結果不整吅",
-    "en": "System error/ Invoice results inconsistent"
-  },
-  "AMPL20003": {
-    "ja": "実行許可のないトランザクションです。",
-    "en": "Cancellation target transaction error: The cancellation target transaction is not immediate"
-  },
-  "AMPL30026": {
-    "ja": "有効なユーザでありません。",
-    "en": "Cancellation target transaction error: Cancelable time exceeded"
-  },
-  "AMPL35000": {
-    "ja": "有効なユーザーでありません。",
-    "en": "Connection request company acceptance denial: Authentication key is not valid time"
-  },
-  "AMPL40004": {
-    "ja": "オーソリ取消が行われています。",
-    "en": "Cancellation target transaction error: Other cancellation target transaction errors"
-  },
-  "AMPL40006": {
-    "ja": "売上取消が行われています。",
-    "en": "Applicable company target business error: System error"
-  },
-  "AMPL40010": {
-    "ja": "後続センターにて処理取消エラーが発生し、有効な初回課金が残りました。",
-    "en": "Connection request Company acceptance denial: IP address error"
-  },
-  "AMPL40104": {
-    "ja": "オーソリ額が限度額を超えています。",
-    "en": "Connection request Company acceptance refusal: Issuer code error"
-  },
-  "AMPL40505": {
-    "ja": "有効なクレジットカードではありません。",
-    "en": "Connection request Company acceptance refusal: Issuer invalid"
-  },
-  "AMPL40506": {
-    "ja": "後続センターにてシステムエラーが発生しました。",
-    "en": "Connection request company acceptance refusal: Expiry date indicator is invalid"
-  },
-  "AMPL90000": {
-    "ja": "後続センターにてシステムエラーが発生しました。",
-    "en": "Connection request company acceptance refusal: Expiry date indicator is invalid"
-  },
-  "AU1000001": {
-    "ja": "【決済要求】後続決済センターとの通信に失敗しました。",
-    "en": "Non-serviceable card: Alliance invalid"
-  },
-  "AU1000002": {
-    "ja": "【決済要求】後続決済センターとの通信パラメータでエラーが発生しました。（受信パラメータ）",
-    "en": "Non-serviceable card: Outside alliance period"
-  },
-  "AU1000003": {
-    "ja": "【決済要求】後続決済センターで障害取消が実施されました。",
-    "en": "Out of Service Card: JET'S Terminal Error"
-  },
-  "AU1000004": {
-    "ja": "【決済要求】 auかんたんOpenID連携解除でエラーが発生しました。",
-    "en": "Cancellation target transaction error: No cancellation target transaction"
-  },
-  "AU1000005": {
-    "ja": "【操作キャンセル】 auかんたん決済でお宠様がお支払をキャンセルしました。",
-    "en": "Cancellation target transaction error: already canceled"
-  },
-  "AU1000006": {
-    "ja": "【決済要求】後続決済センターで処理取消を実行し、取消に失敗しました。",
-    "en": "Connection request Company acceptance denial: Request validation error"
-  },
-  "AU2000007": {
-    "ja": "【課金確認】有効なユーザーでありません。",
-    "en": "Connection request company acceptance denial: authentication key mismatch"
-  },
-  "B01000002": {
-    "ja": "【決済結果問吅せ】楽天Edyセンタから発信する決済開始メールが不達となりました。不達の原因は、携帯端末側のメールアドレス変更、ドメイン拒否等が考えられます。",
-    "en": "There is an error in the specified user email address (attribute error)"
-  },
-  "B01000003": {
-    "ja": "【決済結果問吅せ】楽天Edyセンタに該当の注文番号が存在しません。",
-    "en": "There is an error in the specified mall email address (attribute error)"
-  },
-  "B01000100": {
-    "ja": "決済申込みで指定した注文番号は、既に楽天Edyセンタに登録されています。",
-    "en": "[Settlement Application] There is an error in the designation of affiliated store ID"
-  },
-  "B01001011": {
-    "ja": "指定したモールIDに誤りがあります(タグ自体がない)",
-    "en": "[Settlement Application] There is an error in the password specification"
-  },
-  "B01001012": {
-    "ja": "指定したモールIDに誤りがあります（値なし）",
-    "en": "[Settlement Application] There is an error in the specification of the order number"
-  },
-  "B01001013": {
-    "ja": "指定したモールIDに誤りがあります（サイズエラー）",
-    "en": "[Settlement Application] There is an error in the specification of the amount"
-  },
-  "B01001014": {
-    "ja": "指定したモールIDに誤りがあります（属性エラー）",
-    "en": "[Settlement Application] There is an error in the specification of the user email address"
-  },
-  "B01001021": {
-    "ja": "指定した注文番号に誤りがあります（タグ自体がない）",
-    "en": "[Settlement application] There is an error in the specification of the member store email address"
-  },
-  "B01001022": {
-    "ja": "指定した注文番号に誤りがあります（値なし）",
-    "en": "[Settlement application] There is an error in the designation of the bei"
-  },
-  "B01001023": {
-    "ja": "指定した注文番号に誤りがあります（サイズエラー）",
-    "en": "[Settlement application] There is an error in the specification of the customer"
-  },
-  "B01001024": {
-    "ja": "指定した注文番号に誤りがあります（属性エラー）",
-    "en": "[Settlement application] There is an error in the specification of invoice mail additional information"
-  },
-  "B01001031": {
-    "ja": "指定した購入金額の範囲が誤っています（タグ自体がない）",
-    "en": "[Settlement application] There is an error in the specification of payment completion e-mail additional information"
-  },
-  "B01001032": {
-    "ja": "指定した購入金額の範囲が誤っています（値がない）",
-    "en": "[Settlement application] There is an error in the specification of the store ྡ"
-  },
-  "B01001033": {
-    "ja": "指定した購入金額の範囲が誤っています（サイズエラー）",
-    "en": "[Settlement Application] There is an error in the specification of the settlement end notification URL"
-  },
-  "B01001034": {
-    "ja": "指定した購入金額の範囲が誤っています（属性エラー）",
-    "en": "[Settlement Application] There is an error in the specification of the expiration date"
-  },
-  "B01001035": {
-    "ja": "指定した購入金額の範囲が誤っています（値エラー）",
-    "en": "[Settlement Application] There is an error in the format of XML"
-  },
-  "B01001041": {
-    "ja": "指定したユーザメールアドレスの範囲が誤っています（タグ自体がない）",
-    "en": "[Settlement application] HTML error Content received from Rakuten Edy Center is unexpected content"
-  },
-  "B01001042": {
-    "ja": "指定したユーザメールアドレスの範囲が誤っています（値がない）",
-    "en": "[Settlement result inquiry] There is an error in the specification of the merchant ID"
-  },
-  "B01001043": {
-    "ja": "指定したユーザメールアドレスの範囲が誤っています（サイズエラー）",
-    "en": "[Settlement result inquiry] There is an error in the password specification"
-  },
-  "B01001044": {
-    "ja": "To日付時刻指定（属性エラー）",
-    "en": "[Settlement result inquiry] There is an error in the specification of the order number"
-  },
-  "B01001045": {
-    "ja": "指定したユーザメールアドレスの範囲が誤っています（値エラー）",
-    "en": "[Settlement result question] There is an error in the specification of the From date and time"
-  },
-  "B01001055": {
-    "ja": "指定した＜検索条件＞が指定範囲を超えています",
-    "en": "[Settlement result question] There is an error in the specification of To date and time"
-  },
-  "B01001064": {
-    "ja": "指定した亇備に誤りがあります（属性エラー）",
-    "en": "[Settlement result inquiry] There is an error in the specification of the search pattern"
-  },
-  "B01001083": {
-    "ja": "請求書メール付加の指定に誤りがあります（サイズエラー）",
-    "en": "[Settlement result inquiry] XML error"
-  },
-  "B01001111": {
-    "ja": "決済終了通知の指定に誤りがあります（タグ自体がない）",
-    "en": "[Payment result inquiry] HTML error"
-  },
-  "B01001112": {
-    "ja": "決済終了通知の指定に誤りがあります（値がない）",
-    "en": "HTTP response code received from the center was abnormal (100) HTTP-Status-Continue"
-  },
-  "B01001113": {
-    "ja": "決済終了通知の指定に誤りがあります（サイズエラー）",
-    "en": "The HTTP response code received from the center was abnormal (101) HTTP-Status-SwitchingProtocol"
-  },
-  "B01001114": {
-    "ja": "決済終了通知の指定に誤りがあります（属性エラー）",
-    "en": "The HTTP response code received from the center was abnormal (201) HTTP-Status-Created"
-  },
-  "B01001121": {
-    "ja": "指定した有効期限に誤りがあります（タグ自体がない）",
-    "en": "The HTTP response code received from the center was abnormal (202) HTTP-Status-Accepted"
-  },
-  "B01001122": {
-    "ja": "指定した有効期限に誤りがあります（値がない）",
-    "en": "The HTTP response code received from the center was abnormal (203) HTTP-Status-NonAuthoritativ eInfomation"
-  },
-  "B01001123": {
-    "ja": "指定した有効期限に誤りがあります（サイズエラー)",
-    "en": "The HTTP response code received from the center was abnormal (204) HTTP-Status-NoContent"
-  },
-  "B01001124": {
-    "ja": "指定した有効期限に誤りがあります（属性エラー）",
-    "en": "The HTTP response code received from the center was abnormal (205) HTTP-Status-ResetContent"
-  },
-  "B01001125": {
-    "ja": "指定した有効期限に誤りがあります（値エラー）",
-    "en": "The HTTP response code received from the center was abnormal (206) HTTP-Status-PartialContent"
-  },
-  "B01002001": {
-    "ja": "楽天Edyセンタのサービスが停止しています",
-    "en": "(300) HTTP-Status-Multiple Choices"
-  },
-  "B01002010": {
-    "ja": "指定された加盟店IDは利用できない状態です（未登録）",
-    "en": "(301) HTTP-Status-MovePermanent ly"
-  },
-  "B01002011": {
-    "ja": "指定された加盟店IDは利用できない状態です（閉塞状態）",
-    "en": "(302) HTTP-Status-MovedTempora rily"
-  },
-  "B01002012": {
-    "ja": "指定された加盟店IDは利用できない状態です（適用期間外）",
-    "en": "The server is blocking"
-  },
-  "B01003001": {
-    "ja": "システムエラー1",
-    "en": "(303) HTTP-Status-SeeOther"
-  },
-  "B01003002": {
-    "ja": "システムエラー2",
-    "en": "(304) HTTP-Status-NotModified"
-  },
-  "B01003007": {
-    "ja": "システムエラー3",
-    "en": "(305) HTTP-Status-UseProxy"
-  },
-  "B01003008": {
-    "ja": "システムエラー4",
-    "en": "(400) HTTP-Status-BadRequest"
-  },
-  "B01003009": {
-    "ja": "システムエラー5",
-    "en": "(401) HTTP-Status-Unauthorized"
-  },
-  "B01004001": {
-    "ja": "クライアント証明書の情報と異なる加盟店IDが指定されました",
-    "en": "(402) HTTP-Status-PaymentRequire d"
-  },
-  "B01007001": {
-    "ja": "決済完了URLの指定に誤りがあります（タグ自体がない）",
-    "en": "(403) HTTP-Status-Forbidden"
-  },
-  "B01007002": {
-    "ja": "決済完了URLの指定に誤りがあります（値がない）",
-    "en": "(404) HTTP-Status-NotFound"
-  },
-  "B01007003": {
-    "ja": "決済完了URLの指定に誤りがあります（サイズエラー）",
-    "en": "(405) HTTP-Status-MethodNotAllo wed"
-  },
-  "B01007004": {
-    "ja": "決済完了URLの指定に誤りがあります（属性エラー）",
-    "en": "(406) HTTP-Status-NotAcceptable"
-  },
-  "B01007005": {
-    "ja": "決済完了URLの指定に誤りがあります（値エラー）",
-    "en": "(407) HTTP-Status-ProxyAuthenticationRequired"
-  },
-  "B01007011": {
-    "ja": "指定したユーザメールアドレスに誤りがあります（属性エラー）",
-    "en": "(408) HTTP-Status-RequestTimeout"
-  },
-  "B01007021": {
-    "ja": "指定したモールメールアドレスに誤りがあります（属性エラー）",
-    "en": "(409) HTTP-Status-Conflict"
-  },
-  "B01007600": {
-    "ja": "サーバ閉塞中です",
-    "en": "An error occurred when reading the definition file (log definition file)"
-  },
-  "B01009000": {
-    "ja": "【決済申込み】加盟店IDの指定に誤りがあります",
-    "en": "(410) HTTP-Status-Gone"
-  },
-  "B01009001": {
-    "ja": "【決済申込み】パスワードの指定に誤りがあります",
-    "en": "(411) HTTP-Status-LengthRequired"
-  },
-  "B01009002": {
-    "ja": "【決済申込み】注文番号の指定に誤りがあります",
-    "en": "(412) HTTP-Status-PreconditionFail ed"
-  },
-  "B01009003": {
-    "ja": "【決済申込み】金額の指定に誤りがあります",
-    "en": "(413) HTTP-Status-RequestEntityTo oLarge"
-  },
-  "B01009004": {
-    "ja": "【決済申込み】ユーザメールアドレスの指定に誤りがあります",
-    "en": "(414) HTTP-Status-RequestURITooL ong"
-  },
-  "B01009005": {
-    "ja": "【決済申込み】加盟店様メールアドレスの指定に誤りがあります",
-    "en": "(415) HTTP-Status-UnsupportedMediaType"
-  },
-  "B01009006": {
-    "ja": "【決済申込み】亇備の指定に誤りがあります",
-    "en": "(500) HTTP-Status-InternalServerError"
-  },
-  "B01009007": {
-    "ja": "【決済申込み】顧宠ྡの指定に誤りがあります",
-    "en": "(501) HTTP-Status-NotInplemented"
-  },
-  "B01009008": {
-    "ja": "【決済申込み】請求書メール付加情報の指定に誤りがあります",
-    "en": "(502) HTTP-Status-BadGateway"
-  },
-  "B01009009": {
-    "ja": "【決済申込み】決済完了メール付加情報の指定に誤りがあります",
-    "en": "(503) HTTP-Status-ServiceUnavaila ble"
-  },
-  "B01009010": {
-    "ja": "【決済申込み】店舗ྡの指定に誤りがあります",
-    "en": "(504) HTTP-Status-GatewayTime o t"
-  },
-  "B01009011": {
-    "ja": "【決済申込み】決済終了通知URLの指定に誤りがあります",
-    "en": "(505) HTTP-Status-HTTPVersionNotSupported"
-  },
-  "B01009012": {
-    "ja": "【決済申込み】有効期限の指定に誤りがあります",
-    "en": "Failed to start communication with center"
-  },
-  "B01009013": {
-    "ja": "【決済申込み】 XML の書式に誤りがあります",
-    "en": "Failed to start communication with the center (previous resolution)"
-  },
-  "B01009014": {
-    "ja": "【決済申込み】 HTML エラー楽天Edyセンタから受信した内容が想定外の内容です",
-    "en": "Failed to start communication with center (IP Address resolution)"
-  },
-  "B01009050": {
-    "ja": "【決済結果問吅せ】加盟店IDの指定に誤りがあります",
-    "en": "Failed to start communication with the center (connect)"
-  },
-  "B01009051": {
-    "ja": "【決済結果問吅せ】パスワードの指定に誤りがあります",
-    "en": "An error occurred while communicating with the center"
-  },
-  "B01009052": {
-    "ja": "【決済結果問吅せ】注文番号の指定に誤りがあります",
-    "en": "An error occurred during communication with the center (during reception)"
-  },
-  "B01009053": {
-    "ja": "【決済結果問吅せ】From日付時刻の指定に誤りがあります",
-    "en": "An error occurred during communication with the center (during transmission)"
-  },
-  "B01009054": {
-    "ja": "【決済結果問吅せ】To日付時刻の指定に誤りがあります",
-    "en": "The content received from the center (HTTP Heater r) was abnormal"
-  },
-  "B01009055": {
-    "ja": "【決済結果問吅せ】検索パターンの指定に誤りがあります",
-    "en": "Failed to start communication with Proxy server"
-  },
-  "B01009056": {
-    "ja": "【決済結果問吅せ】XML エラー",
-    "en": "Failed to start communication with the proxy server (previous resolution)"
-  },
-  "B01009057": {
-    "ja": "【決済結果問吅せ】HTML エラー",
-    "en": "Failed to start communication with the proxy server (IP Address resolution)"
-  },
-  "B01009100": {
-    "ja": "センタから受信した HTTPレスポンスコードが異常でした (100)HTTP-Status-Continue",
-    "en": "Communication start (connect) with Proxy server failed"
-  },
-  "B01009101": {
-    "ja": "センタから受信したHTTPレスポンスコードが異常でした (101)HTTP-Status-SwitchingProtoc ol",
-    "en": "An error occurred while communicating with the proxy server"
-  },
-  "B01009201": {
-    "ja": "センタから受信したHTTP レスポンスコードが異常でした (201)HTTP-Status-Created",
-    "en": "An error occurred during communication with the Proxy server (during reception)"
-  },
-  "B01009202": {
-    "ja": "センタから受信したHTTPレスポンスコードが異常でした (202)HTTP-Status-Accepted",
-    "en": "An error occurred during communication with the Proxy server (during transmission)"
-  },
-  "B01009203": {
-    "ja": "センタから受信したHTTP レスポンスコードが異常でした (203)HTTP-Status-NonAuthoritativ eInfomation",
-    "en": "Received content from Proxy server was abnormal"
-  },
-  "B01009204": {
-    "ja": "センタから受信したHTTP レスポンスコードが異常でした (204)HTTP-Status-NoContent",
-    "en": "An error occurred while initializing SSL communication"
-  },
-  "B01009205": {
-    "ja": "センタから受信したHTTP レスポンスコードが異常でした (205)HTTP-Status-ResetContent",
-    "en": "An error occurred during SSL communication handshake"
-  },
-  "B01009206": {
-    "ja": "センタから受信したHTTP レスポンスコードが異常でした (206)HTTP-Status-PartialContent",
-    "en": "An error occurred when receiving SSL communication"
-  },
-  "B01009300": {
-    "ja": "(300)HTTP-Status-MultipleChoices",
-    "en": "An error occurred when sending SSL communication"
-  },
-  "B01009301": {
-    "ja": "(301)HTTP-Status-MovePermanent ly",
-    "en": "An error occurred when reading the definition file (socket definition file)"
-  },
-  "B01009302": {
-    "ja": "(302)HTTP-Status-MovedTempora rily",
-    "en": "An error occurred while reading the definition file (communication definition file)"
-  },
-  "B01009303": {
-    "ja": "(303)HTTP-Status-SeeOther",
-    "en": "An internal error of Rakuten Edy payment program has occurred"
-  },
-  "B01009304": {
-    "ja": "(304)HTTP-Status-NotModified",
-    "en": "An error occurred while interpreting the URL"
-  },
-  "B01009305": {
-    "ja": "(305)HTTP-Status-UseProxy",
-    "en": "An error occurred during character code conversion"
-  },
-  "B01009400": {
-    "ja": "(400)HTTP-Status-BadRequest",
-    "en": "URL protocol error"
-  },
-  "B01009401": {
-    "ja": "(401)HTTP-Status-Unauthorized",
-    "en": "Received SIGTERM"
-  },
-  "B01009402": {
-    "ja": "(402)HTTP-Status-PaymentRequire d",
-    "en": "Failed to interpret XML string"
-  },
-  "B01009403": {
-    "ja": "(403)HTTP-Status-Forbidden",
-    "en": "Mail creation failure"
-  },
-  "B01009404": {
-    "ja": "(404)HTTP-Status-NotFound",
-    "en": "Authentication information fraud"
-  },
-  "B01009405": {
-    "ja": "(405)HTTP-Status-MethodNotAllo wed",
-    "en": "System connection not possible"
-  },
-  "B01009406": {
-    "ja": "(406)HTTP-Status-NotAcceptable",
-    "en": "Invalid data"
-  },
-  "B01009407": {
-    "ja": "(407)HTTP-Status-ProxyAuthenticationRequired",
-    "en": "Non-member or retired member"
-  },
-  "B01009408": {
-    "ja": "(408)HTTP-Status-RequestTimeout",
-    "en": "Number of registerable cases exceeded"
-  },
-  "B01009409": {
-    "ja": "(409)HTTP-Status-Conflict",
-    "en": "Settlement request ID duplication"
-  },
-  "B01009410": {
-    "ja": "(410)HTTP-Status-Gone",
-    "en": "No registration data"
-  },
-  "B01009411": {
-    "ja": "(411)HTTP-Status-LengthRequired",
-    "en": "Temporary invalid member"
-  },
-  "B01009412": {
-    "ja": "(412)HTTP-Status-PreconditionFail ed",
-    "en": "XML format illegal"
-  },
-  "B01009413": {
-    "ja": "(413)HTTP-Status-RequestEntityTo oLarge",
-    "en": "System error Mobile Suica system internal error"
-  },
-  "B01009414": {
-    "ja": "(414)HTTP-Status-RequestURITooL ong",
-    "en": "You will be notified when the Mobile Suica system is stopped for maintenance etc. during system maintenance"
-  },
-  "B01009415": {
-    "ja": "(415)HTTP-Status-UnsupportedMediaType",
-    "en": "Invalid data type"
-  },
-  "B01009500": {
-    "ja": "(500)HTTP-Status-InternalServerError",
-    "en": "UserId / Password does not exist"
-  },
-  "B01009501": {
-    "ja": "(501)HTTP-Status-NotInplemented",
-    "en": "Storage Handling Company Code / Payment Code Mismatch"
-  },
-  "B01009502": {
-    "ja": "(502)HTTP-Status-BadGateway",
-    "en": "2 DBC processing agent number / contract case number do not match"
-  },
-  "B01009503": {
-    "ja": "(503)HTTP-Status-ServiceUnavaila ble",
-    "en": "Payment processing company code / payment code do not match"
-  },
-  "B01009504": {
-    "ja": "(504)HTTP-Status-GatewayTimeou t",
-    "en": "Error when acquiring key data"
-  },
-  "B01009505": {
-    "ja": "(505)HTTP-Status-HTTPVersionNotSupported",
-    "en": "Access was restricted due to a short request overload. Please display / transaction failure and try again."
-  },
-  "B01009600": {
-    "ja": "センタとの通信開始に失敗しました",
-    "en": "Storage process item check error (illegal value)"
-  },
-  "B01009601": {
-    "ja": "センタとの通信開始（ྡ前解決）に失敗しました",
-    "en": "Storage process item check error (Payment code not set)"
-  },
-  "B01009602": {
-    "ja": "センタとの通信開始（IP Address解決）に失敗しました",
-    "en": "Storage processing item check error (payment code digit shortage)"
-  },
-  "B01009603": {
-    "ja": "センタとの通信開始（connect）に失敗しました",
-    "en": "Storage process item check error (reception number not set)"
-  },
-  "B01009604": {
-    "ja": "センタとの通信中にエラーが発生しました",
-    "en": "Storage process item check error (reception number digit missing)"
-  },
-  "B01009605": {
-    "ja": "センタとの通信中（受信時）にエラーが発生しました",
-    "en": "Storage processing item check error (company code not set)"
-  },
-  "B01009606": {
-    "ja": "センタとの通信中（送信時）にエラーが発生しました",
-    "en": "Storage processing item check error (company code digit shortage)"
-  },
-  "B01009607": {
-    "ja": "センタからの受信内容（HTTP Heade r部）が異常でした",
-    "en": "Storage process item check error (phone number not set)"
-  },
-  "B01009610": {
-    "ja": "Proxyサーバとの通信開始に失敗しました",
-    "en": "Storage process item check error (Kanji ྡ not set)"
-  },
-  "B01009611": {
-    "ja": "Proxyサーバとの通信開始（ྡ前解決）に失敗しました",
-    "en": "Storage processing item check error (payment due date not set)"
-  },
-  "B01009612": {
-    "ja": "Proxyサーバとの通信開始（ IP Address解決）に失敗しました",
-    "en": "Storage processing item check error (value other than payment due number)"
-  },
-  "B01009613": {
-    "ja": "Proxyサーバとの通信開始（connect）に失敗しました",
-    "en": "Storage processing item check error (payment deadline digit incorrect)"
-  },
-  "B01009614": {
-    "ja": "Proxyサーバとの通信中にエラーが発生しました",
-    "en": "Storage processing item check error (payment deadline date and time value invalid)"
-  },
-  "B01009615": {
-    "ja": "Proxyサーバとの通信中（受信時）にエラーが発生しました",
-    "en": "Storage processing item check error (payment deadline past date invalid)"
-  },
-  "B01009616": {
-    "ja": "Proxyサーバとの通信中（送信時）にエラーが発生しました",
-    "en": "Storage processing item check error (payment amount not set)"
-  },
-  "B01009617": {
-    "ja": "Proxyサーバからの受信内容が異常でした",
-    "en": "Storage processing item check error (payment amount incorrect)"
-  },
-  "B01009620": {
-    "ja": "SSL通信の初期化中にエラーが発生しました",
-    "en": "Storage processing item check error (payment amount ≦ 0)"
-  },
-  "B01009621": {
-    "ja": "SSL通信の初期化中にエラーが発生しました",
-    "en": "Storage processing item check error (payment amount ≦ 0)"
-  },
-  "B01009622": {
-    "ja": "SSL通信の初期化中にエラーが発生しました",
-    "en": "Storage processing item check error (payment amount ≦ 0)"
-  },
-  "B01009623": {
-    "ja": "SSL通信の初期化中にエラーが発生しました",
-    "en": "Storage processing item check error (payment amount ≦ 0)"
-  },
-  "B01009624": {
-    "ja": "SSL通信の初期化中にエラーが発生しました",
-    "en": "Storage processing item check error (payment amount ≦ 0)"
-  },
-  "B01009625": {
-    "ja": "SSL通信の初期化中にエラーが発生しました",
-    "en": "Storage processing item check error (payment amount ≦ 0)"
-  },
-  "B01009626": {
-    "ja": "SSL通信のハンドシェイク時にエラーが発生しました",
-    "en": "Storage processing item check error (payment amount> 999999)"
-  },
-  "B01009627": {
-    "ja": "SSL通信のハンドシェイク時にエラーが発生しました",
-    "en": "Storage processing item check error (payment amount> 999999)"
-  },
-  "B01009628": {
-    "ja": "SSL通信のハンドシェイク時にエラーが発生しました",
-    "en": "Storage processing item check error (payment amount> 999999)"
-  },
-  "B01009629": {
-    "ja": "SSL通信の受信時にエラーが発生しました",
-    "en": "Storage information duplication error"
-  },
-  "B01009630": {
-    "ja": "SSL通信の送信時にエラーが発生しました",
-    "en": "Storage information logic deleted error"
-  },
-  "B01009700": {
-    "ja": "定義ファイル読込み時にエラーが発生しました（socket定義ファイル）",
-    "en": "Storage process deletion (D) No storage information error"
-  },
-  "B01009701": {
-    "ja": "定義ファイル読込み時にエラーが発生しました（通信定義ファイル）",
-    "en": "Storage process deletion (D) Storage information logic deleted error"
-  },
-  "B01009702": {
-    "ja": "定義ファイル読込み時にエラーが発生しました（ログ定義ファイル）",
-    "en": "Storage process deletion Storage information change impossible error"
-  },
-  "B01009900": {
-    "ja": "楽天Edy決済プログラムの内部エラーが発生しました",
-    "en": "Storage DB OPEN error"
-  },
-  "B01009901": {
-    "ja": "URLの解釈中にエラーが発生しました",
-    "en": "Storage DB READ error"
-  },
-  "B01009902": {
-    "ja": "文字コードの変換中にエラーが発生しました",
-    "en": "Storage DB INSERT error"
-  },
-  "B01009903": {
-    "ja": "URLのプロトコルエラー",
-    "en": "Storage process deletion (D) Storage DB Open error"
-  },
-  "B01009904": {
-    "ja": "SIGTERMを受信しました",
-    "en": "Storage process deletion (D) Storage DB Read error"
-  },
-  "B01009999": {
-    "ja": "XML文字列の解釈に失敗しました",
-    "en": "Storage process deletion (D) Error at storage DB Insert"
-  },
-  "D01000001": {
-    "ja": "システムエラー(通信)/取引失敗を表示し、お問い吅わせ下さい。",
-    "en": "Item number is duplicated."
-  },
-  "D01000002": {
-    "ja": "システムエラー(通信)/取引失敗を表示し、お問い吅わせ下さい。",
-    "en": "Item number is duplicated."
-  },
-  "D01000099": {
-    "ja": "システムエラー(通信)/取引失敗を表示し、お問い吅わせ下さい。",
-    "en": "Item number is duplicated."
-  },
-  "DC1000001": {
-    "ja": "【決済要求】後続決済センターで確定処理が失敗しました。",
-    "en": "Connection request company acceptance denial: Other connection request error"
-  },
-  "DC1000002": {
-    "ja": "【取消要求】後続決済センターで取消処理が失敗しました。",
-    "en": "Cancelable transaction error: Failure cancelable is not immediate"
-  },
-  "DC1000003": {
-    "ja": "【決済中止】お宠様がドコモケータイ払いを中止しました。",
-    "en": "Cancelable transaction error: Failure cancelable time exceeded"
-  },
-  "DC1000004": {
-    "ja": "【決済失敗】ドコモケータイ払いが失敗しました。",
-    "en": "Canceled Transaction Error: Other Canceled Transaction Error"
-  },
-  "DC1000005": {
-    "ja": "【決済中止】お宠様がドコモ継続課金の申込を中止しました。",
-    "en": "Unforeseen error"
-  },
-  "DC1000006": {
-    "ja": "【変更中止】お宠様がドコモ継続課金の変更を中止しました。",
-    "en": "Communication failure with JCB Prika Settlement Center"
-  },
-  "DC1000007": {
-    "ja": "【終了中止】お宠様がドコモ継続課金の終了を中止しました。",
-    "en": "Invalid return value from JCB Prika Settlement Center"
-  },
-  "DC1000008": {
-    "ja": "【決済失敗】ドコモ継続課金の申込が失敗しました。",
-    "en": "Daily limit exceeded"
-  },
-  "DC1000009": {
-    "ja": "【変更失敗】ドコモ継続課金の変更が失敗しました。",
-    "en": "One time limit over limit"
-  },
-  "DC1000010": {
-    "ja": "【終了失敗】ドコモ継続課金の終了が失敗しました。",
-    "en": "Transaction ID check error"
-  },
-  "DC1000011": {
-    "ja": "【増額要求】後続決済センターで増額処理が失敗しました。",
-    "en": "Transaction existence check error"
-  },
-  "E00000000": {
-    "ja": "結果通知プログラム疎通確認用/疎通確認用なので、対処する必要性はありません。",
-    "en": "Please cancel the convenience store transaction error / settlement, and notify you that you can not make a transaction"
-  },
-  "E01010001": {
-    "ja": "ショップIDが指定されていません。",
-    "en": "Shop ID is not set"
-  },
-  "E01010008": {
-    "ja": "ショップIDに半角英数字以外の文字が含まれているか、13文字を超えています。",
-    "en": "Wrong ShopID format (Please make sure that ShopID should have 13 digits of alphanumeric characters only)"
-  },
-  "E01010010": {
-    "ja": "ショップIDが一致しません。",
-    "en": "ShopID does not match"
-  },
-  "E01020001": {
-    "ja": "ショップパスワードが指定されていません。",
-    "en": "The shop password is not specified"
-  },
-  "E01020008": {
-    "ja": "ショップパスワードに半角英数字以外の文字が含まれているか、10文字を超えています。",
-    "en": "Wrong ShopPass format (Please make sure that ShopPass should have 10 alphanumeric characters only)"
-  },
-  "E01030002": {
-    "ja": "指定されたIDとパスワードのショップが存在しません。",
-    "en": "Neither the specified ShopID nor ShopPass does not exist."
-  },
-  "E01030061": {
-    "ja": "強制返品はご利用できません。",
-    "en": "Forced Refund is not available"
-  },
-  "E01040001": {
-    "ja": "オーダーIDが指定されていません。",
-    "en": "The order ID is not specified"
-  },
-  "E01040003": {
-    "ja": "オーダーIDが最大文字数を超えています。",
-    "en": "The order ID exceeds the maximum character number"
-  },
-  "E01040010": {
-    "ja": "すでにオーダーIDが存在しています。",
-    "en": "An order ID already exists"
-  },
-  "E01040013": {
-    "ja": "オーダーIDに半角英数字と”－”以外の文字が含まれています。",
-    "en": "Wrong OrderID format (Please make sure that OrderID should only have alphanumeric characters and \"-\".)"
-  },
-  "E01050001": {
-    "ja": "処理区分が指定されていません。",
-    "en": "\"JobCd\" is not specified."
-  },
-  "E01050002": {
-    "ja": "指定された処理区分は定義されていません。",
-    "en": "The specified \"JobCd\" does not exist."
-  },
-  "E01050004": {
-    "ja": "指定した処理区分の処理は実行できません。",
-    "en": "The specified \"JobCd\" is not available."
-  },
-  "E01060001": {
-    "ja": "利用金額が指定されていません。",
-    "en": "The amount of money is not specified"
-  },
-  "E01060005": {
-    "ja": "利用金額が最大桁数を超えています。",
-    "en": "The amount of money exceeds the maximum digit number"
-  },
-  "E01060006": {
-    "ja": "利用金額に数字以外の文字が含まれています。",
-    "en": "The amount of money contains characters other than numbers"
-  },
-  "E01060010": {
-    "ja": "取引の利用金額と指定した利用金額が一致していません。",
-    "en": "The Order ID was already used. It is possible that you have specified the Order ID again with the different payment amount"
-  },
-  "E01060021": {
-    "ja": "取引の利用金額と指定した利用金額が一致していません。",
-    "en": "Captured amount does not match authorized amount"
-  },
-  "E01070005": {
-    "ja": "税送料が最大桁数を超えています。",
-    "en": "Tax shipping exceeds the maximum digit number"
-  },
-  "E01070006": {
-    "ja": "税送料に数字以外の文字が含まれています。",
-    "en": "Tax shipping includes characters other than numbers"
-  },
-  "E01080007": {
-    "ja": "3Dセキュア使用フラグに0,1以外の値が指定されています。",
-    "en": "Wrong value is set for \"TdFlag\". Please set 0 or 1 for this parameter."
-  },
-  "E01080010": {
-    "ja": "管理画面の設定と一致しません。",
-    "en": "It does not match with the administration screen"
-  },
-  "E01080101": {
-    "ja": "3D必須店舗にも関わらず3Dセキュア使用フラグがOFFになっています。",
-    "en": "Wrong value is set for \"TdFlag\". Please set 1 for this parameter."
-  },
-  "E01090001": {
-    "ja": "取引IDが指定されていません。",
-    "en": "Transaction ID is not specified"
-  },
-  "E01090008": {
-    "ja": "取引IDの書式が正しくありません。",
-    "en": "The form of the transaction ID is not correct"
-  },
-  "E01100001": {
-    "ja": "取引パスワードが指定されていません。",
-    "en": "The transaction password is not specified"
-  },
-  "E01100008": {
-    "ja": "取引パスワードの書式が正しくありません。",
-    "en": "The form of the transaction password is not correct"
-  },
-  "E01110002": {
-    "ja": "指定されたIDとパスワードの取引が存在しません。",
-    "en": "Neither the specified AccessID nor AccessPass does not exist."
-  },
-  "E01110010": {
-    "ja": "指定された取引は決済が完了していません。",
-    "en": "The settlement for this OrderID is not complete"
-  },
-  "E01130012": {
-    "ja": "カード会社略称が最大バイト数を超えています。",
-    "en": "Card company abbreviation exceeds the maximum bytes"
-  },
-  "E01144001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "E01144010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "E01160001": {
-    "ja": "ボーナス分割回数が指定されていません。",
-    "en": "\"PayTimes\" is not specified."
-  },
-  "E01160007": {
-    "ja": "ボーナス分割回数に数字以外の文字が含まれています。",
-    "en": "Wrong characters are specified for \"PayTimes\". Please use numbers only."
-  },
-  "E01160010": {
-    "ja": "ボーナス分割回数に“２”以外を指定しています。",
-    "en": "\"2\" is not specified for \"PayTimes\"."
-  },
-  "E01170001": {
-    "ja": "カード番号が指定されていません。",
-    "en": "The card number is not specified"
-  },
-  "E01170003": {
-    "ja": "カード番号が最大文字数を超えています。",
-    "en": "The card number exceeds the maximum character number"
-  },
-  "E01170006": {
-    "ja": "カード番号に数字以外の文字が含まれています。",
-    "en": "The card number contains characters other than numbers"
-  },
-  "E01170011": {
-    "ja": "カード番号が10桁～16桁の範囲ではありません。",
-    "en": "Wrong card number digits (It should be from 10 to 16 digits.)"
-  },
-  "E01180001": {
-    "ja": "有効期限が指定されていません。",
-    "en": "\"Expire\" is not specified."
-  },
-  "E01180003": {
-    "ja": "有効期限が4桁ではありません。",
-    "en": "Wrong \"Expire\" format (Please make sure this value has to be 4 digits)"
-  },
-  "E01180006": {
-    "ja": "有効期限に数字以外の文字が含まれています。",
-    "en": "The expire date contains characters other than numbers"
-  },
-  "E01180008": {
-    "ja": "有効期限の書式が正しくありません。",
-    "en": "Wrong Format (for \"Expire\")"
-  },
-  "E01180011": {
-    "ja": "有効期限の書式が正しくありません。",
-    "en": "Wrong Format (for \"Expire\")"
-  },
-  "E01190001": {
-    "ja": "サイトIDが指定されていません。",
-    "en": "The site ID is not specified"
-  },
-  "E01190008": {
-    "ja": "サイトIDの書式が正しくありません。",
-    "en": "The form of the site ID is not correct"
-  },
-  "E01200001": {
-    "ja": "サイトパスワードが指定されていません。",
-    "en": "The site password is not specified"
-  },
-  "E01200007": {
-    "ja": "サイトIDが正しくありません。",
-    "en": "Wrong SiteID"
-  },
-  "E01200008": {
-    "ja": "サイトパスワードの書式が正しくありません。",
-    "en": "The form of the site password is not correct"
-  },
-  "E01210002": {
-    "ja": "指定されたIDとパスワードのサイトが存在しません。",
-    "en": "Neither the specified SiteID nor SitePass does not exist."
-  },
-  "E01220001": {
-    "ja": "会員IDが指定されていません。",
-    "en": "The member ID is not specified"
-  },
-  "E01220002": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "E01220005": {
-    "ja": "会員IDが最大桁数を超えています。",
-    "en": "The number of digits for \"MemberID\" exceeds the limit."
-  },
-  "E01220008": {
-    "ja": "会員IDの書式が正しくありません。",
-    "en": "Wrong Format (for \"MemberID\")"
-  },
-  "E01220010": {
-    "ja": "会員IDが重複しています。",
-    "en": "The specified \"SiteID\" has been already used."
-  },
-  "E01220012": {
-    "ja": "会員IDの長さが正しくありません。",
-    "en": "Wrong Length (for \"MemberID\")"
-  },
-  "E01230006": {
-    "ja": "カード登録連番に数字以外の文字が含まれています。",
-    "en": "Wrong characters are specified for \"CardSeq\". Please use numbers only."
-  },
-  "E01230009": {
-    "ja": "カード登録連番が最大登録可能数を超えています。",
-    "en": "The number of registered cards reaches a limit of 5 cards."
-  },
-  "E01240002": {
-    "ja": "指定されたカードが存在しません。",
-    "en": "The specified card does not exist."
-  },
-  "E01240012": {
-    "ja": "指定された会員IDがファイル内で重複しています(※洗替時)",
-    "en": "The specified MemberID duplicates in the uploaded file."
-  },
-  "E01250008": {
-    "ja": "カードパスワードの書式が正しくありません。",
-    "en": "Wrong Format (for \"CardPass\")"
-  },
-  "E01250010": {
-    "ja": "カードパスワードが一致しません。",
-    "en": "Wrong \"CardPass\" entered by the user."
-  },
-  "E01260001": {
-    "ja": "支払方法が指定されていません。",
-    "en": "\"Method\" is not specified."
-  },
-  "E01260002": {
-    "ja": "指定された支払方法が存在しません。",
-    "en": "Wrong value is specified for \"Method\"."
-  },
-  "E01260010": {
-    "ja": "指定されたカード番号または支払方法が正しくありません。",
-    "en": "Either card number or the value set for \"Method\" is the wrong one."
-  },
-  "E01270001": {
-    "ja": "支払回数が指定されていません。",
-    "en": "\"PayTimes\" is not specified."
-  },
-  "E01270005": {
-    "ja": "支払回数が最大桁数を超えています。",
-    "en": "The number of digits for \"PayTimes\" exceeds the limit."
-  },
-  "E01270006": {
-    "ja": "支払回数の数字以外の文字が含まれています。",
-    "en": "Wrong characters are specified for \"PayTimes\". Please use numbers only."
-  },
-  "E01270010": {
-    "ja": "指定された支払回数はご利用できません。",
-    "en": "The specified value is not available for \"PayTimes\"."
-  },
-  "E01290001": {
-    "ja": "HTTP_ACCEPTが指定されていません。",
-    "en": "HTTP_ACCEPT is not specified."
-  },
-  "E01300001": {
-    "ja": "HTTP_USER_AGENTが指定されていません。",
-    "en": "HTTP_USER_AGENT is not specified."
-  },
-  "E01310002": {
-    "ja": "使用端末が指定されていません。",
-    "en": "\"DeviceCategory\" is not specified."
-  },
-  "E01310007": {
-    "ja": "使用端末に”0”,”1”以外の値が指定されています。",
-    "en": "Wrong value is specified for \"DeviceCategory\". The available values are \"0\" or \"1\"."
-  },
-  "E01320012": {
-    "ja": "加盟店自由項目1の値が最大バイト数を超えています。",
-    "en": "The number of bytes for \"ClientField1\" exceeds the limit."
-  },
-  "E01330012": {
-    "ja": "加盟店自由項目2の値が最大バイト数を超えています。",
-    "en": "The number of bytes for \"ClientField2\" exceeds the limit."
-  },
-  "E01340012": {
-    "ja": "加盟店自由項目3の値が最大バイト数を超えています。",
-    "en": "The number of bytes for \"ClientField3\" exceeds the limit."
-  },
-  "E01350001": {
-    "ja": "MDが指定されていません。",
-    "en": "\"MD\" is not specified."
-  },
-  "E01350008": {
-    "ja": "MDの書式が正しくありません。",
-    "en": "Wrong format (for MD)"
-  },
-  "E01360001": {
-    "ja": "PaResが指定されていません。",
-    "en": "\"PaRes\" is not specified."
-  },
-  "E01370008": {
-    "ja": "3Dセキュア表示店舗名の書式が正しくありません。",
-    "en": "\"TdTenantName\" is not specified."
-  },
-  "E01370012": {
-    "ja": "3Dセキュア表示店舗名の値が最大バイト数を超えています。",
-    "en": "The number of bytes for \"TdTenantName\" exceeds the limit."
-  },
-  "E01390002": {
-    "ja": "指定されたサイトIDと会員IDの会員が存在しません。",
-    "en": "Neither the specified SiteID nor MemberID does not exist."
-  },
-  "E01390010": {
-    "ja": "指定されたサイトIDと会員IDの会員がすでに存在しています。",
-    "en": "The specified \"MemberID\" has been already used."
-  },
-  "E01400007": {
-    "ja": "加盟店自由項目返却フラグに”0”,”1”以外の値が指定されています。",
-    "en": "Wrong value is specified for \"DeviceCategory\". The available values are \"0\" or \"1\"."
-  },
-  "E01410010": {
-    "ja": "該当取引は操作禁止状態です。",
-    "en": "The specified Order ID is not allowed to be made any change to."
-  },
-  "E01420010": {
-    "ja": "仮売上有効期間を超えています。",
-    "en": "The provisional sales authorization has expired for the specified Order ID."
-  },
-  "E01430012": {
-    "ja": "会員名の値が最大バイト数を超えています。",
-    "en": "The number of bytes for \"MemberName\" exceeds the limit."
-  },
-  "E01440008": {
-    "ja": "洗替・継続課金フラグの書式が正しくありません。",
-    "en": "Wrong Format (for \"DefaultFlag\")"
-  },
-  "E01450008": {
-    "ja": "商品コードの書式が正しくありません。",
-    "en": "Wrong Format (for \"ItemCode\")"
-  },
-  "E01460008": {
-    "ja": "セキュリティコードの書式が正しくありません。",
-    "en": "Wrong Format (for \"SecurityCode\")"
-  },
-  "E01470008": {
-    "ja": "カード登録連番モードの書式が正しくありません。",
-    "en": "Wrong Format (for \"SeqMode\")"
-  },
-  "E01480008": {
-    "ja": "名義人の書式が正しくありません。",
-    "en": "Wrong Format (for \"HolderName\")"
-  },
-  "E01480011": {
-    "ja": "名義人の最大文字数を超えています。",
-    "en": "The number of characters for \"HolderName\" exceeds the limit."
-  },
-  "E01490005": {
-    "ja": "利用金額・税送料の合計値が最大桁数を超えています。",
-    "en": "The sum of \"Amount\" and \"Tax\" exceeds the limit."
-  },
-  "E01500001": {
-    "ja": "ショップ情報文字列が設定されていません。",
-    "en": "\"ShopPassString\" is not specified."
-  },
-  "E01500005": {
-    "ja": "ショップ情報文字列の文字数が間違っています。",
-    "en": "The number of characters for \"ShopPassString\" is the wrong one. Please make sure that the number of characters should be 32."
-  },
-  "E01500012": {
-    "ja": "ショップ情報文字列が他の項目と矛盾しています。",
-    "en": "Wrong value is set for \"ShopPassString\"."
-  },
-  "E01510001": {
-    "ja": "購買情報文字列が設定されていません。",
-    "en": "Purchase information string is not specified."
-  },
-  "E01510005": {
-    "ja": "購買情報文字列の文字数が間違っています。",
-    "en": "The number of characters for \"CheckString\" is the wrong one. Please make sure that the number of characters should be 32."
-  },
-  "E01510010": {
-    "ja": "利用日の書式が正しくありません。",
-    "en": "Wrong format (for usage date)"
-  },
-  "E01510011": {
-    "ja": "利用日の値が指定可能範囲外です。",
-    "en": "Wrong value is set for usage date."
-  },
-  "E01510012": {
-    "ja": "購買情報文字列が他の項目と矛盾しています。",
-    "en": "There is something wrong with purchase information string."
-  },
-  "E01520002": {
-    "ja": "ユーザー利用端末情報に無効な値が設定されています。",
-    "en": "Invalid value is set for \"UserInfo\"."
-  },
-  "E01530001": {
-    "ja": "決済結果戻り先URLが設定されていません。",
-    "en": "\"RetURL\" is not specified."
-  },
-  "E01530005": {
-    "ja": "決済結果戻り先URLが最大文字数を超えています。",
-    "en": "The number of characters exceeds the limit for \"RetURL\"."
-  },
-  "E01540005": {
-    "ja": "決済キャンセル時URLが最大文字数を超えています。",
-    "en": "The number of characters exceeds the limit for \"CancelURL\"."
-  },
-  "E01550001": {
-    "ja": "日時情報文字列が設定されていません。",
-    "en": "\"DateTime\" is not specified."
-  },
-  "E01550005": {
-    "ja": "日時情報文字列の文字数が間違っています。",
-    "en": "Wrong format (for DateTime) *It should be in the format of yyyyMMddhhmmss"
-  },
-  "E01550006": {
-    "ja": "日時情報文字列に無効な文字が含まれます。",
-    "en": "Invalid value is set for \"DateTime\"."
-  },
-  "E01590005": {
-    "ja": "商品コードが最大桁数を超えています。",
-    "en": "The number of characters exceeds the limit for \"ItemCode\"."
-  },
-  "E01590006": {
-    "ja": "商品コードに無効な文字が含まれます。",
-    "en": "Invalid value is set for \"ItemCode\"."
-  },
-  "E01600001": {
-    "ja": "会員情報チェック文字列が設定されていません。",
-    "en": "\"MemberPassString\" is not specified."
-  },
-  "E01600005": {
-    "ja": "会員情報チェック文字列が最大文字数を超えています。",
-    "en": "The number of characters exceeds the limit for \"MemberPassString\"."
-  },
-  "E01600012": {
-    "ja": "会員情報チェック文字列が他の項目と矛盾しています。",
-    "en": "Wrong value is set for \"MemberPassString\"."
-  },
-  "E01610005": {
-    "ja": "リトライ回数が0～99の範囲外です。",
-    "en": "The value for \"RetryMax\" is not from 0 to 99."
-  },
-  "E01610006": {
-    "ja": "リトライ回数に数字以外が設定されています。",
-    "en": "Wrong format (for RetryMax). Please use numbers only."
-  },
-  "E01620005": {
-    "ja": "セッションタイムアウト値が0～9999の範囲外です。",
-    "en": "The value for \"SessionTimeout\" is not from 0 to 9999."
-  },
-  "E01620006": {
-    "ja": "セッションタイムアウト値に数字以外が設定されています。",
-    "en": "Wrong format (for \"SessionTimeout\"). Please use numbers only."
-  },
-  "E01630010": {
-    "ja": "取引後カード登録時、取引の会員IDとパラメータの会員IDが一致しません。",
-    "en": "Wrong MemberID is specified."
-  },
-  "E01640010": {
-    "ja": "取引後カード登録時、取引のサイトIDとパラメータのサイトIDが一致しません。",
-    "en": "Wrong SiteID is specified."
-  },
-  "E01650012": {
-    "ja": "指定されたショップは、指定されたサイトに属していません。",
-    "en": "Wrong ShopID is specified."
-  },
-  "E01660013": {
-    "ja": "言語パラメータにサポートされない値が設定されています。",
-    "en": "Wrong value is set for \"Lang\"."
-  },
-  "E01670013": {
-    "ja": "出力エンコーディングにサポートされない値が設定されています。",
-    "en": "The value set for \"Enc\" is not supported."
-  },
-  "E01700001": {
-    "ja": "項目数が誤っています。",
-    "en": "There is something wrong with the number of parameters."
-  },
-  "E01710001": {
-    "ja": "取引区分(継続課金)が設定されていません。",
-    "en": "Recurring flag is not set for the order."
-  },
-  "E01710002": {
-    "ja": "指定された取引区分が存在しません。",
-    "en": "The specified transaction type does not exist."
-  },
-  "E01730001": {
-    "ja": "ボーナス金額が指定されていません。",
-    "en": "Bonus payment amount is not specified."
-  },
-  "E01730005": {
-    "ja": "ボーナス金額が最大桁数を超えています。",
-    "en": "The number of characters exceeds the limit for bonus payment amount."
-  },
-  "E01730006": {
-    "ja": "商品コードが”0000990”ではありません。",
-    "en": "\"0000990\" is not specified for Item Code."
-  },
-  "E01730007": {
-    "ja": "ボーナス金額に数字以外の文字が含まれています。",
-    "en": "Wrong format (for bonus payment amount). Please use numbers only."
-  },
-  "E01740001": {
-    "ja": "端末処理通番が指定されていません。",
-    "en": "Terminal processing sequence number is not specified."
-  },
-  "E01740005": {
-    "ja": "端末処理通番が最大桁数を超えています。",
-    "en": "The number of characters exceeds the limit for terminal processing sequence number."
-  },
-  "E01740007": {
-    "ja": "端末処理通番に数字以外の文字が含まれています。",
-    "en": "Wrong format (for terminal processing sequence number). Please use numbers only."
-  },
-  "E01750001": {
-    "ja": "利用日が指定されていません。",
-    "en": "Usage date is not specified."
-  },
-  "E01750008": {
-    "ja": "利用日の書式が正しくありません。",
-    "en": "Wrong format (for usage date)"
-  },
-  "E01770002": {
-    "ja": "区分が不正です。",
-    "en": "Invalid Value is set for transaction type."
-  },
-  "E01780002": {
-    "ja": "有効性チェック有無が不正です。",
-    "en": "Invalid value is set for card validity check. Please set \"0\" for this parameter."
-  },
-  "E01790007": {
-    "ja": "チェック実施日が不正です。",
-    "en": "Invalid value is set for check date."
-  },
-  "E01790011": {
-    "ja": "チェック実施日が最大桁数を超えています。",
-    "en": "The number of characters exceeds the limit for check date."
-  },
-  "E01800001": {
-    "ja": "暗証番号が未入力です。",
-    "en": "Password is not specified."
-  },
-  "E01800008": {
-    "ja": "暗証番号の書式が正しくありません。",
-    "en": "Wrong format (for password)"
-  },
-  "E01800010": {
-    "ja": "暗証番号は利用できません。",
-    "en": "Invalid password"
-  },
-  "E01800050": {
-    "ja": "暗証番号が不正です。(0000は使用できません)",
-    "en": "Invalid password (0000 is not available)"
-  },
-  "E01810001": {
-    "ja": "磁気ストライプ区分が不正です。",
-    "en": "Magnetic stripe type is invalid"
-  },
-  "E01810008": {
-    "ja": "磁気ストライプ区分が不正です。",
-    "en": "Magnetic stripe type is invalid"
-  },
-  "E01820001": {
-    "ja": "磁気ストライプ情報が不正です。",
-    "en": "Magnetic stripe info is invalid"
-  },
-  "E01820003": {
-    "ja": "磁気ストライプ情報が不正です。",
-    "en": "Magnetic stripe info is invalid"
-  },
-  "E01820008": {
-    "ja": "磁気ストライプ情報が不正です。",
-    "en": "Magnetic stripe info is invalid"
-  },
-  "E01840010": {
-    "ja": "必要な入力パラメータが指定されていません。",
-    "en": "The specified parameters are not sufficient."
-  },
-  "E01850008": {
-    "ja": "更新区分の書式が正しくありません。",
-    "en": "Wrong format (for \"UpdateType\")"
-  },
-  "E01860008": {
-    "ja": "カード番号マスクフラグの書式が正しくありません。",
-    "en": "Wrong format (for Card Number Masking Flag)"
-  },
-  "E01870008": {
-    "ja": "トークンタイプの書式が正しくありません。",
-    "en": "Wrong format (for TokenType)"
-  },
-  "E01880001": {
-    "ja": "登録済み会員IDが指定されていません。",
-    "en": "\"MemberID\" is not specified."
-  },
-  "E01880002": {
-    "ja": "指定されたサイトIDと登録済み会員IDの会員が存在しません。",
-    "en": "Neither the specified SiteID nor MemberID does not exist."
-  },
-  "E01880008": {
-    "ja": "登録済み会員IDの書式が正しくありません。",
-    "en": "Wrong format (for \"MemberID\")"
-  },
-  "E01890001": {
-    "ja": "登録済みカード登録連番が指定されていません。",
-    "en": "\"CardSeq\" is not specified."
-  },
-  "E01890002": {
-    "ja": "指定された登録済みカードが存在しません。",
-    "en": "The specified \"MemberID\" does not exist."
-  },
-  "E01890006": {
-    "ja": "登録済みカード登録連番に数字以外の文字が含まれています。",
-    "en": "Wrong format (for \"CardSeq\"). Please use numbers only."
-  },
-  "E01890009": {
-    "ja": "カード登録連番が最大登録可能数を超えています。",
-    "en": "Card cannot be registered for the specified MemberID. Please note that each MemberID can have up to 5 cards."
-  },
-  "E01999998": {
-    "ja": "項目1「フォーマットバージョン」に\"001\"が指定されていません。",
-    "en": "\"001\" is not specified for \"Format Version\"."
-  },
-  "E11010001": {
-    "ja": "この取引はすでに決済が終了しています。",
-    "en": "The specified Order ID has already completed its settlement."
-  },
-  "E11010002": {
-    "ja": "この取引は決済が終了していませんので、変更する事ができません。",
-    "en": "The status cannot be changed for the specified OrderID because this order has not been settled yet."
-  },
-  "E11010003": {
-    "ja": "この取引は指定処理区分処理を行う事ができません。",
-    "en": "The specified \"JobCd\" is not available for this OrderID. "
-  },
-  "E11010010": {
-    "ja": "180日超えの取引のため、処理を行う事ができません。",
-    "en": "The status of this OrderID cannot be changed because it was settled more than 180 days ago."
-  },
-  "E11010011": {
-    "ja": "コンビニ取引エラー/決済を中止して、取引が出来ない஦を通知して下さい。",
-    "en": "Check email link payment call error / setting."
-  },
-  "E11010012": {
-    "ja": "モバイルSuica取引エラー/決済を中止して、取引が出来ない஦を通知して下さい。",
-    "en": "Check link settlement call error / setting."
-  },
-  "E11010013": {
-    "ja": "楽天edy取引エラー/決済を中止して、取引が出来ない஦を通知して下さい。",
-    "en": "Please stop the transaction error / settlement and notify you that you can not trade."
-  },
-  "E11010014": {
-    "ja": "Pay-easy取引エラー/決済を中止して、取引が出来ない஦を通知して下さい。",
-    "en": "Transaction error / The transaction may have been completed."
-  },
-  "E11010017": {
-    "ja": "リクルートかんたん支払い決済取引エラー/決済を中止して、取引が出来ない஦を通知して下さい。",
-    "en": "Display the system error / transaction failure, please check the situation by asking."
-  },
-  "E11010099": {
-    "ja": "このカードはご利用になれません。",
-    "en": "This card is not available."
-  },
-  "E11010999": {
-    "ja": "取引エラー/既に取引が完了している可能性があります。",
-    "en": "Please stop the member store setting error / settlement and check the setting status of the net bank by asking."
-  },
-  "E11310001": {
-    "ja": "この取引はリンク決済を実行できません。",
-    "en": "Link type payment cannot be executed for this OrderID."
-  },
-  "E11310002": {
-    "ja": "この取引はリンク決済を実行できません。",
-    "en": "Link type payment cannot be executed for this OrderID."
-  },
-  "E11310003": {
-    "ja": "この取引はリンク決済を実行できません。",
-    "en": "Link type payment cannot be executed for this OrderID."
-  },
-  "E11310004": {
-    "ja": "この取引はリンク決済を実行できません。",
-    "en": "Link type payment cannot be executed for this OrderID."
-  },
-  "E11310005": {
-    "ja": "すでにカードを登録している会員は、取引後カード登録を実行できません。",
-    "en": "Card registration failed because this MemberID has already registered a card."
-  },
-  "E21010001": {
-    "ja": "3Dセキュア認証に失敗しました。もう一度、購入画面からやり直してください。",
-    "en": "There is something wrong with 3DS authentication. Please try again later."
-  },
-  "E21010007": {
-    "ja": "3Dセキュア認証に失敗しました。もう一度、購入画面からやり直してください。",
-    "en": "There is something wrong with 3DS authentication. Please try again later."
-  },
-  "E21010201": {
-    "ja": "このカードでは取引をする事ができません。3Dセキュア認証に対応したカードをお使いください。",
-    "en": "Settlment process failed because the card is non-3DS compliant."
-  },
-  "E21010202": {
-    "ja": "このカードでは取引をする事ができません。3Dセキュア認証に対応したカードをお使いください。",
-    "en": "Settlement process failed because the card is non-3DS compliant."
-  },
-  "E21010999": {
-    "ja": "3Dセキュア認証に失敗しました。もう一度、購入画面からやり直してください。",
-    "en": "There is something wrong with 3DS authentication. Please try again later."
-  },
-  "E21020001": {
-    "ja": "3Dセキュア認証に失敗しました。もう一度、購入画面からやり直してください。",
-    "en": "There is something wrong with 3DS authentication. Please try again later."
-  },
-  "E21020002": {
-    "ja": "3Dセキュア認証がキャンセルされました。もう一度、購入画面からやり直してください。",
-    "en": "3DS authentication was cancelled. Please try again later."
-  },
-  "E21020007": {
-    "ja": "3Dセキュア認証に失敗しました。もう一度、購入画面からやり直してください。",
-    "en": "There is something wrong with 3DS authentication. Please try again later."
-  },
-  "E21020999": {
-    "ja": "3Dセキュア認証に失敗しました。もう一度、購入画面からやり直してください。",
-    "en": "There is something wrong with 3DS authentication. Please try again later."
-  },
-  "E31500014": {
-    "ja": "加盟店実行エラー/リクエストメソッドがGETになっています。POSTに変更して下さい。",
-    "en": "There is an error in the specified order number (no value)"
-  },
-  "E41170002": {
-    "ja": "入力されたカード会社に対応していません。別のカード番号を入力してください。",
-    "en": "Settlement process failed because the card is not available on our system."
-  },
-  "E41170099": {
-    "ja": "カード番号に誤りがあります。再度確認して入力してください。",
-    "en": "There is something wrong with card number."
-  },
-  "E61010001": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "E61010002": {
-    "ja": "ご利用出来ないカードをご利用になったもしくはカード番号が誤っております。",
-    "en": "Invalid card is being used, or there is something wrong with card number."
-  },
-  "E61010003": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "E61020001": {
-    "ja": "指定の決済方法は利用停止になっています。",
-    "en": "The specified payment method is not available."
-  },
-  "E61030001": {
-    "ja": "ご契約内容エラー/現在のご契約では、ご利用になれません。",
-    "en": "Your request cannot be accepted under the current merchant contract."
-  },
-  "E61040001": {
-    "ja": "現在のご契約では、カード番号を指定した決済処理は許可されていません。",
-    "en": "Raw PAN (=card number) cannot be processed under the current merchant contract."
-  },
-  "E61145002": {
-    "ja": "加盟店設定エラー/決済を中止して、問い吅わせにて LINE Pay設定状況を確認して下さい。",
-    "en": "System error 4"
-  },
-  "E61152002": {
-    "ja": "加盟店設定エラー/決済を中止して、問い吅わせにてネット銀聯設定状況を確認して下さい。",
-    "en": "System error 5"
-  },
-  "E61214002": {
-    "ja": "ショップ設定の銀行振込(バーチャル口座)部に不備があります。",
-    "en": "Input parameter error / Template No. not specified"
-  },
-  "E61214010": {
-    "ja": "当該機能は専有口座契約でのみ利用可能です。",
-    "en": "Input parameter error / Invalid template number format"
-  },
-  "E61219002": {
-    "ja": "利用可能なバーチャル口座がありません。",
-    "en": "Input parameter error / Message language No. not specified"
-  },
-  "E61258001": {
-    "ja": "加盟店設定エラー/加盟店ྡ称が設定されていません。マルペイ管理画面の都度決済＞ネット銀聯＞設定画面にて加盟店ྡ称を設定してください。",
-    "en": "A merchant ID different from the client certificate information has been specified"
-  },
-  "E61300002": {
-    "ja": "メールリンク設定が行われていない。",
-    "en": "Input parameter error / Town square · Address digit excess"
-  },
-  "E82010001": {
-    "ja": "実行中にエラーが発生しました。処理は開始されませんでした。",
-    "en": "An error occurred and your request was declined."
-  },
-  "E90010001": {
-    "ja": "現在処理を行っているのでもうしばらくお待ちください。",
-    "en": "Please wait until we complete processing."
-  },
-  "E91019999": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "E91020001": {
-    "ja": "通信タイムアウトが発生しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Timeout occurred. Please try again later."
-  },
-  "E91029998": {
-    "ja": "決済処理に失敗しました。該当のお取引について、店舗までお問い合わせください。",
-    "en": "Settlement process failed. Please contact the merchant."
-  },
-  "E91029999": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "E91050001": {
-    "ja": "決済処理に失敗しました。",
-    "en": "Settlement process failed."
-  },
-  "E91060001": {
-    "ja": "システムの内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い合わせください。",
-    "en": "An error occurred. Please ask GMO-PG to confirm the status by informing us of process date & time and the transmitted parameters."
-  },
-  "E91099996": {
-    "ja": "システムの内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い合わせください。",
-    "en": "An error occurred. Please ask GMO-PG to confirm the status by informing us of process date & time and the transmitted parameters."
-  },
-  "E91099997": {
-    "ja": "リクエストされたAPIは存在しません。URLをお確かめください。",
-    "en": "There is something wrong with the API URL."
-  },
-  "E91099999": {
-    "ja": "決済処理に失敗しました。申し訳ございませんが、しばらく時間をあけて購入画面からやり直してください。",
-    "en": "Settlement process failed. Please try again later."
-  },
-  "E92000001": {
-    "ja": "只今、大変込み合っていますので、しばらく時間をあけて再度決済を行ってください。",
-    "en": "The order failed to be processed because of heavy traffic. Please try again later."
-  },
-  "E92000002": {
-    "ja": "只今、大変込み合っていますので、しばらく時間をあけて再度決済を行ってください。",
-    "en": "The order failed to be processed because of heavy traffic. Please try again later."
-  },
-  "EX1000301": {
-    "ja": "決済処理に失敗しました。もう一度カード番号を入力してください。",
-    "en": "Settlement process failed. Please enter card number again."
-  },
-  "EX1000302": {
-    "ja": "決済処理に失敗しました。もう一度カード番号を入力してください。",
-    "en": "Settlement process failed. Please enter card number again."
-  },
-  "EX1000303": {
-    "ja": "決済処理に失敗しました。もう一度カード番号を入力してください。",
-    "en": "Settlement process failed. Please enter card number again."
-  },
-  "EX1000304": {
-    "ja": "決済処理に失敗しました。もう一度カード番号を入力してください。",
-    "en": "Settlement process failed. Please enter card number again."
-  },
-  "FM1999001": {
-    "ja": "ファミリマート・決済要求エラー/取引失敗を表示し、お問い吅わせ下さい。",
-    "en": "Item number and transaction ID are irregular."
-  },
-  "FM1999002": {
-    "ja": "ファミリマート・決済キャンセル要求エラー/取引失敗を表示し、お問い吅わせ下さい。",
-    "en": "Invalid eBay connection information."
-  },
-  "J01000001": {
-    "ja": "【決済失敗】後続決済センターで決済が失敗しました。",
-    "en": "State transition check error (expired)"
-  },
-  "J01000002": {
-    "ja": "【決済中止】お宠様がじぶん銀行決済を中止しました。",
-    "en": "State transition check error (illegal transition)"
-  },
-  "J01000003": {
-    "ja": "【決済失敗】後続決済センターでྡ義不一致により決済が失敗しました。",
-    "en": "Expired"
-  },
-  "J01100001": {
-    "ja": "【決済失敗】後続決済センターで原因不明エラーにより決済が失敗しました。",
-    "en": "State transition error"
-  },
-  "J01100002": {
-    "ja": "【決済失敗】想定外のエラーコードが返却されました。",
-    "en": "Payment NG"
-  },
-  "JP1000001": {
-    "ja": "残高不足",
-    "en": "MD5 check error"
-  },
-  "JP1000002": {
-    "ja": "入金金額オーバー",
-    "en": "Payment information acquisition error"
-  },
-  "JP1000003": {
-    "ja": "未アクティベート",
-    "en": "Settlement result parameter check error (presence or absence of settlement date for settlement result)"
-  },
-  "JP1000004": {
-    "ja": "利用開始前",
-    "en": "Transition to URL at the time of purchase information content check error"
-  },
-  "JP1000005": {
-    "ja": "認証番号エラー",
-    "en": "Settlement inconsistencies (results notification for transactions for which settlement failed)"
-  },
-  "JP1000006": {
-    "ja": "無効カード",
-    "en": "Shop identification not possible"
-  },
-  "JP1000007": {
-    "ja": "会員番号エラー",
-    "en": "SCD not set"
-  },
-  "JP1000008": {
-    "ja": "有効期限エラー",
-    "en": "Usage stop check error"
-  },
-  "JP1000009": {
-    "ja": "サービス対象外カード：券種コードエラー",
-    "en": "There is no linked transaction (Purchase information output)"
-  },
-  "JP1000010": {
-    "ja": "サービス対象外カード：アライアンス期間外",
-    "en": "There is no linked transaction (payment result notification)"
-  },
-  "JP1000011": {
-    "ja": "サービス対象外カード：アライアンス無効",
-    "en": "State transition check error (illegal transition)"
-  },
-  "JP1000012": {
-    "ja": "サービス対象外カード：アライアンス許可取引外",
-    "en": "State transition check error (settled)"
-  },
-  "JP1000013": {
-    "ja": "サービス対象外カード：その他アライアンス取引エラー",
-    "en": "No purchase information"
-  },
-  "JP1000014": {
-    "ja": "サービス対象外カード：その他アライアンス取引エラー",
-    "en": "No purchase information"
-  },
-  "JP1000015": {
-    "ja": "サービス対象外カード：JCBセンター会社未登録エラー",
-    "en": "Settlement disorder error"
-  },
-  "JP1000016": {
-    "ja": "サービス対象外カード：JCBPOS支店チェックエラー",
-    "en": "Other error"
-  },
-  "JP1000017": {
-    "ja": "サービス対象外カード：JCB加盟店有効エラー",
-    "en": "System error (* 1)"
-  },
-  "JP1000018": {
-    "ja": "サービス対象外カード： JET'S端末エラー",
-    "en": "System error"
-  },
-  "JP1000019": {
-    "ja": "取消対象取引エラー：取消対象取引なし",
-    "en": "It is not refundable because the refundable date has passed."
-  },
-  "JP1000020": {
-    "ja": "取消対象取引エラー：既に取消済み",
-    "en": "The maximum number of transactions that can be queried has been exceeded (100). Please check the occurrence time and call parameters and ask."
-  },
-  "JP1000021": {
-    "ja": "取消対象取引エラー：取消対象取引が直近ではない",
-    "en": "Payment has expired"
-  },
-  "JP1000022": {
-    "ja": "取消対象取引エラー：取消可能時間超過",
-    "en": "The merchant's configuration information is incorrect."
-  },
-  "JP1000023": {
-    "ja": "取消対象取引エラー：その他取消対象取引エラー",
-    "en": "There is a defect in the payment method selected by the user. Please check with the user."
-  },
-  "JP1000024": {
-    "ja": "取消対象取引エラー：その他取消対象取引エラー",
-    "en": "There is a defect in the payment method selected by the user. Please check with the user."
-  },
-  "JP1000025": {
-    "ja": "取消対象取引エラー：その他取消対象取引エラー",
-    "en": "There is a defect in the payment method selected by the user. Please check with the user."
-  },
-  "JP1000026": {
-    "ja": "該当自社対象業務エラー：システムエラー",
-    "en": "User information is invalid. Please check with the user."
-  },
-  "JP1000027": {
-    "ja": "該当自社対象業務エラー：システムエラー",
-    "en": "User information is invalid. Please check with the user."
-  },
-  "JP1000028": {
-    "ja": "該当自社対象業務エラー：システムエラー",
-    "en": "User information is invalid. Please check with the user."
-  },
-  "JP1000029": {
-    "ja": "該当自社対象業務エラー：システムエラー",
-    "en": "User information is invalid. Please check with the user."
-  },
-  "JP1000030": {
-    "ja": "該当自社対象業務エラー：システムエラー",
-    "en": "User information is invalid. Please check with the user."
-  },
-  "JP1000031": {
-    "ja": "該当自社対象業務エラー：システムエラー",
-    "en": "User information is invalid. Please check with the user."
-  },
-  "JP1000032": {
-    "ja": "該当自社対象業務エラー：システムエラー",
-    "en": "User information is invalid. Please check with the user."
-  },
-  "JP1000033": {
-    "ja": "接続要求自社受付拒否：発行会社コードエラー",
-    "en": "LINE Pay internal error. Please check the occurrence time and call parameters and ask."
-  },
-  "JP1000034": {
-    "ja": "接続要求自社受付拒否：発行会社無効",
-    "en": "System internal error. Please check the occurrence time and call parameters and ask."
-  },
-  "JP1000035": {
-    "ja": "接続要求自社受付拒否：有効期限区分が不正",
-    "en": "Reception error (communication message error)"
-  },
-  "JP1000036": {
-    "ja": "接続要求自社受付拒否：リクエストバリデーションエラー",
-    "en": "Reception error (processing deadline exceeded)"
-  },
-  "JP1000037": {
-    "ja": "接続要求自社受付拒否：認証キー不一致",
-    "en": "Ginkgo error (request failure) Actual sales / return / cancel request failed. Ginko's internal error. Please check the occurrence time and call parameters and ask."
-  },
-  "JP1000038": {
-    "ja": "接続要求自社受付拒否：認証キーが有効時間外",
-    "en": "Ginkgo Error (Other) It is an internal error of Ginkgo. Please check the occurrence time and call parameters and ask."
-  },
-  "JP1000039": {
-    "ja": "接続要求自社受付拒否：IPアドレスエラー",
-    "en": "Failed to create billing data at the beginning of the month."
-  },
-  "JP1000040": {
-    "ja": "接続要求自社受付拒否：その他接続要求エラー",
-    "en": "Failed to confirm billing data on billing day."
-  },
-  "JP1000041": {
-    "ja": "接続要求自社受付拒否：その他接続要求エラー",
-    "en": "Failed to confirm billing data on billing day."
-  },
-  "JP1000042": {
-    "ja": "接続要求自社受付拒否：その他接続要求エラー",
-    "en": "Failed to confirm billing data on billing day."
-  },
-  "JP1000043": {
-    "ja": "接続要求自社受付拒否：その他接続要求エラー",
-    "en": "Failed to confirm billing data on billing day."
-  },
-  "JP1000044": {
-    "ja": "障害取消対象取引エラー：障害取消対象が直近ではない",
-    "en": "The first charge at the time of charge application failed."
-  },
-  "JP1000045": {
-    "ja": "障害取消対象取引エラー：障害取消可能時間超過",
-    "en": "Cancel refund request failure"
-  },
-  "JP1000046": {
-    "ja": "障害取消対象取引エラー：その他障害取消対象取引エラー",
-    "en": "State transition check error (registered)"
-  },
-  "JP1000047": {
-    "ja": "障害取消対象取引エラー：その他障害取消対象取引エラー",
-    "en": "State transition check error (registered)"
-  },
-  "JP1000048": {
-    "ja": "亇期しないエラー",
-    "en": "No purchase information"
-  },
-  "JP1000049": {
-    "ja": "JCBプリカ決済センターとの通信失敗",
-    "en": "Failed to apply for billing."
-  },
-  "JP1000050": {
-    "ja": "JCBプリカ決済センターからの戻り値不正",
-    "en": "Processing failed due to user cancellation."
-  },
-  "JP1000051": {
-    "ja": "１日あたり利用限度額オーバー",
-    "en": "Input parameter error / specified transaction invalid"
-  },
-  "JP1000052": {
-    "ja": "１回あたり利用限度額オーバー",
-    "en": "Input parameter error / incorrect amount"
-  },
-  "LP1000001": {
-    "ja": "状態遷移チェックエラー(不正な遷移)",
-    "en": "Input parameter error / billing customer's phone number excess digits"
-  },
-  "LP1000002": {
-    "ja": "状態遷移チェックエラー(期限切れ)",
-    "en": "Input parameter error / card expiration date not specified"
-  },
-  "LP1000003": {
-    "ja": "状態遷移チェックエラー(決済済み)",
-    "en": "Input parameter error / non billing customer number"
-  },
-  "LP1001163": {
-    "ja": "払い戻し可能日を過ぎているため、払い戻し出来ません。",
-    "en": "Input parameter error / other than the number of days elapsed since user ID registration"
-  },
-  "LP1001177": {
-    "ja": "照会可能な最大取引数を超えました(100 件)。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
-    "en": "Input parameter error / shipping address information judgment flag incorrect format"
-  },
-  "LP1001180": {
-    "ja": "支払の有効期限が経過しました",
-    "en": "Input parameter error / Delivery destination number of digits exceeded"
-  },
-  "LP1009001": {
-    "ja": "加盟店の設定情報が不正です。",
-    "en": "Input parameter error / shipping destination surname surpasses the number of digits"
-  },
-  "LP1009002": {
-    "ja": "利用者が選択した決済手段に不備があります。利用者にご確認ください。",
-    "en": "Input parameter error / shipping address exceeded one digit"
-  },
-  "LP1009003": {
-    "ja": "利用者情報が不正です。利用者にご確認ください。",
-    "en": "Input parameter error / shipping address 2 digit excess"
-  },
-  "LP2009900": {
-    "ja": "LINE Payの内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
-    "en": "Input parameter error / Shipment address exceeded 3 digits"
-  },
-  "LP2009999": {
-    "ja": "システムの内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
-    "en": "Input parameter error / shipping destination prefecture digit excess"
-  },
-  "LW1310004": {
-    "ja": "ローソン・ミニストップ処理要求エラー/ユーザがLoppi操作中、または操作済のため処理に失敗しました。",
-    "en": "eBay connection information is incorrect."
-  },
-  "M01001005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01002001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01002002": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01002008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01002010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01003001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01003008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01004001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01004002": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01004010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01004012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01004013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01004014": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01005001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01005005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01005006": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01005011": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01006005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01006006": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01007001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01007008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01008001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01008008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01009001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01009002": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01009005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01009010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01010001": {
-    "ja": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
-    "en": "There is an error in the specified expiration date (no value)"
-  },
-  "M01010012": {
-    "ja": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
-    "en": "There is an error in the specified expiration date (no value)"
-  },
-  "M01010013": {
-    "ja": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
-    "en": "There is an error in the specified expiration date (no value)"
-  },
-  "M01011001": {
-    "ja": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
-    "en": "There is an error in the specified expiration date (no value)"
-  },
-  "M01011012": {
-    "ja": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
-    "en": "There is an error in the specified expiration date (no value)"
-  },
-  "M01011013": {
-    "ja": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
-    "en": "There is an error in the specified expiration date (no value)"
-  },
-  "M01012001": {
-    "ja": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
-    "en": "There is an error in the specified expiration date (no value)"
-  },
-  "M01012005": {
-    "ja": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
-    "en": "There is an error in the specified expiration date (no value)"
-  },
-  "M01012008": {
-    "ja": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
-    "en": "There is an error in the specified expiration date (no value)"
-  },
-  "M01013005": {
-    "ja": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
-    "en": "There is an error in the specified expiration date (no value)"
-  },
-  "M01013006": {
-    "ja": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
-    "en": "There is an error in the specified expiration date (no value)"
-  },
-  "M01013011": {
-    "ja": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
-    "en": "There is an error in the specified expiration date (no value)"
-  },
-  "M01014001": {
-    "ja": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
-    "en": "There is an error in the specified expiration date (no value)"
-  },
-  "M01014005": {
-    "ja": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
-    "en": "There is an error in the specified expiration date (no value)"
-  },
-  "M01014008": {
-    "ja": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
-    "en": "There is an error in the specified expiration date (no value)"
-  },
-  "M01015005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01015008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01016012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01016013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01017012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01017013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01018012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01018013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01019012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01019013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01020012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01020013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01021012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01021013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01022012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01022013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01023012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01023013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01024012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01024013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01025012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01025013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01026012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01026013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01027012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01027013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01028012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01028013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01029012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01029013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01030012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01030013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01031012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01031013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01032012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01032013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01033012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01033013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01034012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01034013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01035012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01035013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01036001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01036012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01036013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01037001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01037005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01037008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01038001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01038005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01038008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01039005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01039008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01039012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01039013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01040005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01040008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01040012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01040013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01041005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01041008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01041012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01041013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01042005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01042011": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01043001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01043012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01043013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01044012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01044013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01045012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01045013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01046012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01046013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01047012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01047013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01048005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01048006": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01048011": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01049012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01049013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01050012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01050013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01051001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01051005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01051011": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01052011": {
-    "ja": "取引エラー/処理が出来ない஦を通知して下さい。",
-    "en": "There is an error in the specified expiration date (size error)"
-  },
-  "M01053002": {
-    "ja": "設定を確認して下さい。",
-    "en": "There is an error in the specified expiration date (attribute error)"
-  },
-  "M01054001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01054004": {
-    "ja": "取引エラー/取引の状態を確認して下さい。",
-    "en": "There is an error in the specified expiration date (value error)"
-  },
-  "M01054010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01055001": {
-    "ja": "入力パラメータエラー／金額不正",
-    "en": "Other than input parameter error / user point balance number"
-  },
-  "M01055010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01055011": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01056001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01056012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01057010": {
-    "ja": "取引エラー/処理が出来ない஦を通知して下さい。",
-    "en": "There is an error in the specified expiration date (size error)"
-  },
-  "M01058002": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01058004": {
-    "ja": "入力パラメータエラー／指定された取引が無効",
-    "en": "Input parameter error / user point balance digit excess"
-  },
-  "M01058010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01058011": {
-    "ja": "ドコモ決済にて決済後、規定時間以内にキャンセル又は増額しようとした",
-    "en": "Rakuten Edy Center service is down"
-  },
-  "M01059001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01059005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01059012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01060010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01061001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01061002": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01061005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01062001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01062002": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01062005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01063001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01063002": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01064001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01064003": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01064013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01065001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01065003": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01065013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01066001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01066003": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01066013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01067001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01067003": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01067013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01068001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01068003": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01068013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01069001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01069003": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01069013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01070001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01070002": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01071001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01071005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01071006": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01073001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01073002": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01073004": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01074090": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01074091": {
-    "ja": "入力パラメータエラー/設定を確認してください。",
-    "en": "Check the input parameter error / setting."
-  },
-  "M01074101": {
-    "ja": "入力パラメータエラー/設定を確認してください。",
-    "en": "Check the input parameter error / setting."
-  },
-  "M01074108": {
-    "ja": "入力パラメータエラー/設定を確認してください。",
-    "en": "Check the input parameter error / setting."
-  },
-  "M01075001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01075005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01075013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01076001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01076010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01077005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01077013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01078005": {
-    "ja": "通貨コード桁数エラー",
-    "en": "The designated merchant ID can not be used (not registered)"
-  },
-  "M01078010": {
-    "ja": "通貨コード妥当性エラー",
-    "en": "The designated merchant ID can not be used (blocked)"
-  },
-  "M01079010": {
-    "ja": "ロケール妥当性エラー",
-    "en": "The designated merchant ID can not be used (outside of the applicable period)"
-  },
-  "M01080001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01080005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01080013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01081011": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01081013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01082001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01082005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01082013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01083001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01083008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01084002": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01085001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01085005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01085006": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01085010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01085011": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01086001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01086005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01086006": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01086010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01087012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01087013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01088012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01088013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01089010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01091001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01091010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01092001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01092010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01093001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01093004": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01093010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01094001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01094008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01095010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01096010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01097010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01098010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01100012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01100013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01101001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01105001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01105005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01107001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01107005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01107010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01108012": {
-    "ja": "メールリンク決済呼び出しエラー/設定を確認してください。",
-    "en": "System error 2"
-  },
-  "M01108013": {
-    "ja": "メールリンク決済呼び出しエラー/設定を確認してください。",
-    "en": "System error 2"
-  },
-  "M01109012": {
-    "ja": "メールリンク決済呼び出しエラー/設定を確認してください。",
-    "en": "System error 2"
-  },
-  "M01109013": {
-    "ja": "メールリンク決済呼び出しエラー/設定を確認してください。",
-    "en": "System error 2"
-  },
-  "M01110012": {
-    "ja": "メールリンク決済呼び出しエラー/設定を確認してください。",
-    "en": "System error 2"
-  },
-  "M01111012": {
-    "ja": "メールリンク決済呼び出しエラー/設定を確認してください。",
-    "en": "System error 2"
-  },
-  "M01111013": {
-    "ja": "メールリンク決済呼び出しエラー/設定を確認してください。",
-    "en": "System error 2"
-  },
-  "M01112001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01112005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01112008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01112012": {
-    "ja": "メールリンク決済呼び出しエラー/設定を確認してください。",
-    "en": "System error 2"
-  },
-  "M01112013": {
-    "ja": "メールリンク決済呼び出しエラー/設定を確認してください。",
-    "en": "System error 2"
-  },
-  "M01113001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01113005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01113008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01114005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01114008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01115010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01120001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01120010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01120012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01120013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01121001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01121002": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01121005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01121008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01121012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01121013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01122005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01122008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01122012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01122013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01123001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01123005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01123008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01123012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01124001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01124005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01125001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01125005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01126011": {
-    "ja": "処理が出来ない஦を通知して下さい。",
-    "en": "System error 1"
-  },
-  "M01127011": {
-    "ja": "処理が出来ない஦を通知して下さい。",
-    "en": "System error 1"
-  },
-  "M01128008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01129001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01129005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01129010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01129013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01130008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01130012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01131001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01131005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01131006": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01131010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01131011": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01133001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01133005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01133006": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01134008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01135005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01135010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01135013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01136001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01136005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01137005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01138005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01139005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01140005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01141001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01141005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01141006": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01141011": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01142005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01142006": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01148010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01150001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01150012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01151005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01153005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01153013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01157001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01157005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01158001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01158005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01158006": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01160008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01160010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01161008": {
-    "ja": "入力パラメータエラー／請求先情報有無判定フラグ書式不正",
-    "en": "Input parameter error / commodity IAN / JAN code digit excess"
-  },
-  "M01162005": {
-    "ja": "入力パラメータエラー／ユーザ ID桁数超過",
-    "en": "Input parameter error / product IAN / JAN code incorrect"
-  },
-  "M01163005": {
-    "ja": "入力パラメータエラー／カードྡ義桁数超過",
-    "en": "Input parameter error / Product category digit excess"
-  },
-  "M01163008": {
-    "ja": "入力パラメータエラー／カードྡ義書式不正",
-    "en": "Input parameter error / unit price digit excess"
-  },
-  "M01164005": {
-    "ja": "入力パラメータエラー／請求先顧宠苗字桁数超過",
-    "en": "Input parameter error / other than unit price number"
-  },
-  "M01165005": {
-    "ja": "入力パラメータエラー／請求先顧宠住所１桁数超過",
-    "en": "Input parameter error / product number of digits excess"
-  },
-  "M01166005": {
-    "ja": "入力パラメータエラー／請求先顧宠住所２桁数超過",
-    "en": "Input parameter error / over 10 item number overruns"
-  },
-  "M01167005": {
-    "ja": "入力パラメータエラー／請求先顧宠住所３桁数超過",
-    "en": "Input parameter error / over 10 item number overruns"
-  },
-  "M01168005": {
-    "ja": "入力パラメータエラー／請求先顧宠都道府県桁数超過",
-    "en": "Input parameter error / over-fill item over 19 digits"
-  },
-  "M01169005": {
-    "ja": "入力パラメータエラー／請求先顧宠郵便番号桁数超過",
-    "en": "Input parameter error / over 20 items in excess"
-  },
-  "M01169008": {
-    "ja": "入力パラメータエラー／請求先顧宠郵便番号書式不正",
-    "en": "Input parameter error / excellent item other than 20 numbers"
-  },
-  "M01170005": {
-    "ja": "入力パラメータエラー／請求先顧宠電話番号桁数超過",
-    "en": "Input parameter error / over-fill item over 21 digit number"
-  },
-  "M01170006": {
-    "ja": "入力パラメータエラー／請求先顧宠電話番号数値以外",
-    "en": "Input parameter error / Excess item over 22 digit number"
-  },
-  "M01171005": {
-    "ja": "入力パラメータエラー／請求先顧宠メールアドレス桁数超過",
-    "en": "Input parameter error / overrun item over 23 digits"
-  },
-  "M01171008": {
-    "ja": "入力パラメータエラー／請求先顧宠メールアドレス書式不正",
-    "en": "Input parameter error / over 24 items in excess"
-  },
-  "M01172008": {
-    "ja": "入力パラメータエラー／エンドユーザ IPアドレス書式不正",
-    "en": "Input parameter error / over 25 items in excess"
-  },
-  "M01173008": {
-    "ja": "入力パラメータエラー／リピータフラグ書式不正",
-    "en": "Input parameter error / currency code digit excess"
-  },
-  "M01174005": {
-    "ja": "入力パラメータエラー／ユーザ ID登録後経過日数桁数超過",
-    "en": "Input parameter error / incorrect currency code format"
-  },
-  "M01174006": {
-    "ja": "入力パラメータエラー／ユーザ ID登録後経過日数数値以外",
-    "en": "Input parameter error / billing customer exceeded number of digits"
-  },
-  "M01175008": {
-    "ja": "入力パラメータエラー／発送先情報有無判定フラグ書式不正",
-    "en": "Input parameter error / Billing customer country format incorrect"
-  },
-  "M01176005": {
-    "ja": "入力パラメータエラー／発送先ྡ前桁数超過",
-    "en": "Input parameter error / message type excess digits"
-  },
-  "M01177005": {
-    "ja": "入力パラメータエラー／発送先苗字桁数超過",
-    "en": "Transaction existence check error"
-  },
-  "M01178005": {
-    "ja": "入力パラメータエラー／発送先住所１桁数超過",
-    "en": "Request falsification check error"
-  },
-  "M01179005": {
-    "ja": "入力パラメータエラー／発送先住所２桁数超過",
-    "en": "Recruit easy payment end reception: State transition error"
-  },
-  "M01180005": {
-    "ja": "入力パラメータエラー／発送先住所３桁数超過",
-    "en": "Payment failure error"
-  },
-  "M01181005": {
-    "ja": "入力パラメータエラー／発送先都道府県桁数超過",
-    "en": "Request Parameter Abnormal In the Subsequent Settlement Center, request parameters are returned if they differ from the specifications."
-  },
-  "M01182005": {
-    "ja": "入力パラメータエラー／発送先郵便番号桁数超過",
-    "en": "Processing status error In a subsequent settlement center, this occurs when the status is not for processing."
-  },
-  "M01182008": {
-    "ja": "入力パラメータエラー／発送先郵便番号書式不正",
-    "en": "Failed to refund processing. It occurs when the amount to be refunded is greater than the payment amount at the subsequent settlement center, or the repayment period has passed."
-  },
-  "M01183005": {
-    "ja": "入力パラメータエラー／加盟店ྡ桁数超過",
-    "en": "Point full settlement error point This occurs when the follow-up settlement center can not accept processing because of full settlement."
-  },
-  "M01183008": {
-    "ja": "入力パラメータエラー／加盟店ྡ書式不正",
-    "en": "Credit card error Occurs when credit card credit acquisition fails."
-  },
-  "M01184005": {
-    "ja": "入力パラメータエラー／デバイス情報桁数超過",
-    "en": "Recruit easy payment settlement result reception status check error"
-  },
-  "M01185005": {
-    "ja": "入力パラメータエラー／再購入日数桁数超過",
-    "en": "Recruit communication error"
-  },
-  "M01185006": {
-    "ja": "入力パラメータエラー／再購入日数数値以外",
-    "en": "Recruit easy payment settlement result reception input parameter error"
-  },
-  "M01186005": {
-    "ja": "入力パラメータエラー／過去購買回数桁数超過",
-    "en": "Recruit easy payment settlement result receive transaction existence check error"
-  },
-  "M01186006": {
-    "ja": "入力パラメータエラー／過去購買回数数値以外",
-    "en": "API server exception It is an internal error of the subsequent settlement center. Please check the occurrence time and call parameters and ask."
-  },
-  "M01187008": {
-    "ja": "入力パラメータエラー／与信結果書式不正",
-    "en": "No data error This error occurs when there is no data that matches the request parameter in the subsequent settlement center."
-  },
-  "M01188008": {
-    "ja": "入力パラメータエラー／郵便局・営業所留フラグ書式不正",
-    "en": "Maintenance during maintenance It occurs when maintenance is in progress in the subsequent settlement center and processing can not be accepted."
-  },
-  "M01189005": {
-    "ja": "入力パラメータエラー／郵便局・営業所ྡ桁数超過",
-    "en": "Execution permission error This error occurs when the API can not accept processing because you do not have permission to execute the API."
-  },
-  "M01190005": {
-    "ja": "入力パラメータエラー／ユーザポイント残高桁数超過",
-    "en": "Shop ID check error This error occurs when you accept a shop ID that does not exist in the subsequent settlement center."
-  },
-  "M01190006": {
-    "ja": "入力パラメータエラー／ユーザポイント残高数値以外",
-    "en": "Total amount out of range error This error occurs when the total amount exceeds the number of significant digits in the subsequent settlement center."
-  },
-  "M01191005": {
-    "ja": "入力パラメータエラー／カード登録変更回数桁数超過",
-    "en": "Order ID check error This error occurs when you receive an order ID that does not exist in the subsequent settlement center."
-  },
-  "M01191006": {
-    "ja": "入力パラメータエラー／カード登録変更回数数値以外",
-    "en": "Other system error"
-  },
-  "M01192005": {
-    "ja": "入力パラメータエラー／商品情報繰り返し回数桁数超過",
-    "en": "Recruit simple payment continued billing end received: status transition error"
-  },
-  "M01192006": {
-    "ja": "入力パラメータエラー／商品情報繰り返し回数数値以外",
-    "en": "Unhandled error This occurs when the purchaser is unable to accept processing, such as the purchaser is on the blacklist, at a subsequent settlement center."
-  },
-  "M01193005": {
-    "ja": "入力パラメータエラー／商品個数桁数超過",
-    "en": "Continuation charge failure error This occurs when a continual charge fails in the subsequent settlement center."
-  },
-  "M01193006": {
-    "ja": "入力パラメータエラー／商品個数数値以外",
-    "en": "Continuation charge failure Forced cancellation In the case of a settlement center, it occurs when continual charge fails and is forcibly canceled."
-  },
-  "M01194005": {
-    "ja": "入力パラメータエラー／商品識別コード桁数超過",
-    "en": "Continuing charge failed because of cancellation."
-  },
-  "M01194008": {
-    "ja": "入力パラメータエラー／商品識別コード書式不正",
-    "en": "Recruit simple payment continuation charge result reception status check error"
-  },
-  "M01195005": {
-    "ja": "入力パラメータエラー／商品IAN/JANコード桁数超過",
-    "en": "Recruit easy continuation charge actual sales error"
-  },
-  "M01195008": {
-    "ja": "入力パラメータエラー／商品IAN/JANコード書式不正",
-    "en": "Recruit simple continuation charge Actual cancellation failure After cancellation error"
-  },
-  "M01196005": {
-    "ja": "入力パラメータエラー／商品カテゴリー桁数超過",
-    "en": "Recruit simple continuation charge result receive transaction existence check error"
-  },
-  "M01197005": {
-    "ja": "入力パラメータエラー／商品単価桁数超過",
-    "en": "Merchant ID check error This error occurs when you receive a merchant ID that does not exist in the subsequent settlement center."
-  },
-  "M01197006": {
-    "ja": "入力パラメータエラー／商品単価数値以外",
-    "en": "Product ID check error This error occurs when you receive a product ID that does not exist in the subsequent settlement center."
-  },
-  "M01198005": {
-    "ja": "入力パラメータエラー／商品ྡ桁数超過",
-    "en": "Item amount check error This error occurs when you receive an item amount that does not exist in the subsequent settlement center."
-  },
-  "M01199001": {
-    "ja": "入力パラメータエラー／カード番号未指定",
-    "en": "Input parameter error / card registration change number of digits exceeded"
-  },
-  "M01199005": {
-    "ja": "入力パラメータエラー／カード番号桁数超過",
-    "en": "Other than input parameter error / card registration change number value"
-  },
-  "M01199006": {
-    "ja": "入力パラメータエラー／カード番号数値以外",
-    "en": "Input parameter error / other than product information repetition number numerical value"
-  },
-  "M01199011": {
-    "ja": "入力パラメータエラー／カード番号桁数範囲不正",
-    "en": "Input parameter error / product information repeated number of digits excess"
-  },
-  "M01200001": {
-    "ja": "入力パラメータエラー／カード有効期限未指定",
-    "en": "Input parameter error / product number digit excess"
-  },
-  "M01200005": {
-    "ja": "入力パラメータエラー／カード有効期限桁数超過",
-    "en": "Other than input parameter error / item number"
-  },
-  "M01200006": {
-    "ja": "入力パラメータエラー／カード有効期限数値以外",
-    "en": "Input parameter error / item identification code digit number excess"
-  },
-  "M01201001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01201008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01202001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01202006": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01202010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01203001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01203005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01203006": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01203010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01204002": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01205005": {
-    "ja": "入力パラメータエラー／亇備項目8桁数超過",
-    "en": "Order No., Contract No. Check Error This error occurs when you receive an order No. (Contract No.) that does not exist in the Subsequent Settlement Center."
-  },
-  "M01206005": {
-    "ja": "入力パラメータエラー／亇備項目9桁数超過",
-    "en": "There is a defect in the bank transfer (virtual account) department of the shop settings."
-  },
-  "M01207005": {
-    "ja": "入力パラメータエラー／亇備項目19桁数超過",
-    "en": "The feature is only available with a proprietary account contract."
-  },
-  "M01208005": {
-    "ja": "入力パラメータエラー／亇備項目20桁数超過",
-    "en": "There is no virtual account available."
-  },
-  "M01208006": {
-    "ja": "入力パラメータエラー／亇備項目20数値以外",
-    "en": "Expiration days required error"
-  },
-  "M01209005": {
-    "ja": "入力パラメータエラー／亇備項目21桁数超過",
-    "en": "Expiration day digits exceeded"
-  },
-  "M01210005": {
-    "ja": "入力パラメータエラー／亇備項目22桁数超過",
-    "en": "Expiration days format error"
-  },
-  "M01211005": {
-    "ja": "入力パラメータエラー／亇備項目23桁数超過",
-    "en": "Number of digits for transaction open"
-  },
-  "M01212005": {
-    "ja": "入力パラメータエラー／亇備項目24桁数超過",
-    "en": "Transaction free prohibition character check error"
-  },
-  "M01213005": {
-    "ja": "入力パラメータエラー／亇備項目25桁数超過",
-    "en": "Transfer requester Mr. number of digits over"
-  },
-  "M01215001": {
-    "ja": "有効期限日数必須エラー",
-    "en": "Input parameter error / Invalid message language No. format"
-  },
-  "M01215005": {
-    "ja": "有効期限日数桁数オーバー",
-    "en": "Input parameter error / Invalid range of valid days"
-  },
-  "M01215006": {
-    "ja": "有効期限日数フォーマットエラー",
-    "en": "Input parameter error / Currency code error\n  - The specified currency code does not exist.\n  - The amount of money used exceeds the maximum amount of money for the specified currency code.\n  - A currency code that can not be used by the specified payment method is specified"
-  },
-  "M01216012": {
-    "ja": "取引஦由桁数オーバー",
-    "en": "Mail link has not been set."
-  },
-  "M01216013": {
-    "ja": "取引஦由禁則文字チェックエラー",
-    "en": "Input parameter error / Transfer specified date not specified"
-  },
-  "M01217012": {
-    "ja": "振込依頼者氏ྡ桁数オーバー",
-    "en": "Input parameter error / Transfer specified date format incorrect"
-  },
-  "M01217013": {
-    "ja": "振込依頼者氏ྡ禁則文字チェックエラー",
-    "en": "Input parameter error / billing number of digits exceeded"
-  },
-  "M01218005": {
-    "ja": "メールアドレス桁数オーバー",
-    "en": "Input parameter error / Billing content format incorrect"
-  },
-  "M01218008": {
-    "ja": "メールアドレスフォーマットエラー",
-    "en": "Input parameter error / Incorrect check mode"
-  },
-  "M01219004": {
-    "ja": "指定された口座は使用中です。（未使用状態ではありません）",
-    "en": "Input parameter error / specified account does not exist"
-  },
-  "M01220001": {
-    "ja": "継続口座ID必須エラー",
-    "en": "Error in input parameter / account transfer is out of process."
-  },
-  "M01220002": {
-    "ja": "指定された口座IDが存在しません。",
-    "en": "Input parameter error / Out of charge acceptance period"
-  },
-  "M01220005": {
-    "ja": "口座ID入力桁数オーバー",
-    "en": "System error / Billing acceptance failure"
-  },
-  "M01220010": {
-    "ja": "継続口座状態エラー割当済みの口座を割り当て、もしく解放済みの口座を解放しようとしています。",
-    "en": "System error / Billing deadline failure"
-  },
-  "M01220013": {
-    "ja": "継続口座ID禁則文字エラー",
-    "en": "System error / Billing result reflection failure"
-  },
-  "M01221001": {
-    "ja": "銀行コード必須エラー",
-    "en": "System error / Inconsistent result"
-  },
-  "M01221005": {
-    "ja": "銀行コード桁数オーバー",
-    "en": "There is no trade in Paid."
-  },
-  "M01221006": {
-    "ja": "銀行コードフォーマットエラー",
-    "en": "An error code (call parameter invalid) was returned from Paid."
-  },
-  "M01222001": {
-    "ja": "支店コード必須エラー",
-    "en": "An error occurred on the Paid side."
-  },
-  "M01222005": {
-    "ja": "支店コード桁数オーバー",
-    "en": "The request number limit has been exceeded."
-  },
-  "M01222006": {
-    "ja": "支店コードフォーマットエラー",
-    "en": "An unexpected status has been returned from Paid."
-  },
-  "M01223001": {
-    "ja": "科目必須エラー",
-    "en": "The specified trading partner is not available."
-  },
-  "M01223011": {
-    "ja": "科目フォーマットエラー",
-    "en": "The specified trading partner is over the limit amount."
-  },
-  "M01224001": {
-    "ja": "口座番号必須エラー",
-    "en": "An error code (illegal parameter) was returned from Paid."
-  },
-  "M01224005": {
-    "ja": "口座番号桁数オーバー",
-    "en": "An error code (insufficient parameter content) was returned from Paid."
-  },
-  "M01224006": {
-    "ja": "口座番号フォーマットエラー",
-    "en": "An error code (Paid customer ID registered) has been returned from Paid."
-  },
-  "M01225002": {
-    "ja": "入金履歴存在チェックエラー入金履歴は存在しません。",
-    "en": "The specified Paid customer ID does not exist."
-  },
-  "M01226012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01226013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01227012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01228005": {
-    "ja": "入力パラメータエラー／実行モード桁数超過",
-    "en": "Input parameter error / product identification code incorrect format"
-  },
-  "M01229005": {
-    "ja": "入力パラメータエラー／通貨コード桁数超過",
-    "en": "Transfer requester Mr. ྡ prohibition character check error"
-  },
-  "M01229008": {
-    "ja": "入力パラメータエラー／通貨コード書式不正",
-    "en": "Email address digit over"
-  },
-  "M01230005": {
-    "ja": "入力パラメータエラー／請求先顧宠国桁数超過",
-    "en": "Email address format error"
-  },
-  "M01230008": {
-    "ja": "入力パラメータエラー／請求先顧宠国書式不正",
-    "en": "The specified account is in use. (Not in unused state)"
-  },
-  "M01231005": {
-    "ja": "入力パラメータエラー／電文タイプ桁数超過",
-    "en": "Continuation account ID required error"
-  },
-  "M01232001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01232005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01232013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01233011": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01234010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01235010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01236002": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01237011": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01238001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01238005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01238008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01238010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01239001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01239005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01239008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01240001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01240005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01241001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01241005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01241008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01242001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01242005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01242008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01243010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01250001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01250005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01250012": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01250013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01251001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01251006": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01251010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01252001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01252008": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01253001": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01253005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01253006": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01253010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01254002": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01255011": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01257010": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01259010": {
-    "ja": "口座情報入力不正継続口座IDもしくは、口座情報 (銀行コード、支店コード、科目コード、口座番号)のいずれかを指定してください。",
-    "en": "An error code (others) has been returned from Paid."
-  },
-  "M01290001": {
-    "ja": "入力パラメータエラー /実行モード未指定",
-    "en": "The specified trading partner has been registered."
-  },
-  "M01290008": {
-    "ja": "入力パラメータエラー /実行モード書式不正",
-    "en": "Input parameter error / Customer ID not specified"
-  },
-  "M01291001": {
-    "ja": "入力パラメータエラー /注文番号未指定",
-    "en": "Input parameter error / Business partner ID digit excess"
-  },
-  "M01291005": {
-    "ja": "入力パラメータエラー /注文番号桁数超過",
-    "en": "Input parameter error / Business partner ID format incorrect"
-  },
-  "M01291008": {
-    "ja": "入力パラメータエラー /注文番号書式不正",
-    "en": "Input parameter error / company ྡ not specified"
-  },
-  "M01291010": {
-    "ja": "入力パラメータエラー /注文番号重複（すでに使用された注文番号を指定）",
-    "en": "Input parameter error / company number of digits excess"
-  },
-  "M01292001": {
-    "ja": "入力パラメータエラー /商品ྡ未指定",
-    "en": "Input parameter error / Company ྡ Kana not specified"
-  },
-  "M01292005": {
-    "ja": "入力パラメータエラー /商品ྡ桁数超過",
-    "en": "Input parameter error / Company ྡ number of digits excess"
-  },
-  "M01292008": {
-    "ja": "入力パラメータエラー /商品ྡ書式不正",
-    "en": "Input parameter error / representative surname not specified"
-  },
-  "M01293001": {
-    "ja": "入力パラメータエラー /通貨コード未指定",
-    "en": "Input parameter error / representative surname digit number excess"
-  },
-  "M01293005": {
-    "ja": "入力パラメータエラー /通貨コード桁数超過",
-    "en": "Input parameter error / representative ྡ not specified"
-  },
-  "M01293008": {
-    "ja": "入力パラメータエラー /通貨コード書式不正",
-    "en": "Input parameter error / representative 者 number of digits excess"
-  },
-  "M01294001": {
-    "ja": "入力パラメータエラー /購入者氏ྡ未指定",
-    "en": "Input parameter error / Representative surname Kana not specified"
-  },
-  "M01294005": {
-    "ja": "入力パラメータエラー /購入者氏ྡ桁数超過",
-    "en": "Input parameter error / representative surname surpasses kana digit number excess"
-  },
-  "M01294008": {
-    "ja": "入力パラメータエラー /購入者氏ྡ書式不正",
-    "en": "Input parameter error / Representative company ྡ Kana not specified"
-  },
-  "M01295001": {
-    "ja": "入力パラメータエラー /メールアドレス未指定",
-    "en": "Input parameter error / Representative company ྡ Kana digit number excess"
-  },
-  "M01295005": {
-    "ja": "入力パラメータエラー /メールアドレス桁数超過",
-    "en": "Input parameter error / Zip code not specified"
-  },
-  "M01296001": {
-    "ja": "入力パラメータエラー /テンプレートNo.未指定",
-    "en": "Input parameter error / Incorrect postal code format"
-  },
-  "M01296008": {
-    "ja": "入力パラメータエラー / テンプレートNo.書式不正",
-    "en": "Input parameter error / Unspecified state"
-  },
-  "M01297001": {
-    "ja": "入力パラメータエラー / メッセージ言語No.未指定",
-    "en": "Input parameter error / State digit excess"
-  },
-  "M01297008": {
-    "ja": "入力パラメータエラー / メッセージ言語No.書式不正",
-    "en": "Input parameter error / city not specified"
-  },
-  "M01298011": {
-    "ja": " 入力パラメータエラー / 有効日数範囲不正",
-    "en": "Input parameter error / municipality number of digits excess"
-  },
-  "M01299010": {
-    "ja": "入力パラメータエラー / 通貨コードエラー・指定した通貨コードが存在しない。\n・指定した通貨コードの上限金額を超えた利用金額が指定された。\n・指定した決済手段で使用できない通貨コードが指定された",
-    "en": "Input parameter error / Street address / address not specified"
-  },
-  "M01320005": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01320013": {
-    "ja": "入力パラメータエラー/設定を確認して下さい。",
-    "en": "Mobile Suica Trading Error / Cancel settlement, please notify that you can not trade."
-  },
-  "M01330001": {
-    "ja": "入力パラメータエラー /振替指定日未指定",
-    "en": "Input parameter error/ Debiting day not defined"
-  },
-  "M01330006": {
-    "ja": "入力パラメータエラー /振替指定日書式不正",
-    "en": "Input parameter error/ Debiting day format error"
-  },
-  "M01330010": {
-    "ja": "入力パラメータエラー /振替指定日書式不正",
-    "en": "Input parameter error/ Debiting day format error"
-  },
-  "M01331005": {
-    "ja": "入力パラメータエラー /請求内容桁数超過",
-    "en": "Input parameter error/ Invoice contents character limit exceeded"
-  },
-  "M01331006": {
-    "ja": "入力パラメータエラー /請求内容書式不正",
-    "en": "Input parameter error/ Invoice contents format error"
-  },
-  "M01332002": {
-    "ja": "入力パラメータエラー / 指定された口座は存在しません",
-    "en": "Input parameter error/ Specified bank account does not exist"
-  },
-  "M01333002": {
-    "ja": "入力パラメータエラー / 口座振替の処理可能期間外です。",
-    "en": "Input parameter error/ Outside of direct debiting processing period"
-  },
-  "M01333011": {
-    "ja": "入力パラメータエラー / 請求受付期間外",
-    "en": "Input parameter error/ Outside of invoicing period"
-  },
-  "M01334011": {
-    "ja": "入力パラメータエラー / 請求受付期間外",
-    "en": "Input parameter error/ Outside of invoicing period"
-  },
-  "M01335005": {
-    "ja": "入力パラメータエラー /チェックモード不正",
-    "en": "Input parameter error / person in charge ྡ not specified"
-  },
-  "M01335006": {
-    "ja": "入力パラメータエラー/チェックモードエラー",
-    "en": "Input parameter error/ Check mode error"
-  },
-  "M01360001": {
-    "ja": "入力パラメータエラー /取引先 ID未指定",
-    "en": "Input parameter error / Number of stores out of range"
-  },
-  "M01360005": {
-    "ja": "入力パラメータエラー /取引先 ID桁数超過",
-    "en": "Input parameter error / URL one digit excess"
-  },
-  "M01360008": {
-    "ja": "入力パラメータエラー /取引先 ID書式不正",
-    "en": "Input parameter error / Invalid URL1 format"
-  },
-  "M01361001": {
-    "ja": "入力パラメータエラー /会社 ྡ未指定",
-    "en": "Input parameter error / URL 2 digits excess"
-  },
-  "M01361005": {
-    "ja": "入力パラメータエラー /会社 ྡ桁数超過",
-    "en": "Input parameter error / URL2 format invalid"
-  },
-  "M01362001": {
-    "ja": "入力パラメータエラー /会社 ྡカナ未指定",
-    "en": "Input parameter error / URL 3 digits excess"
-  },
-  "M01362005": {
-    "ja": "入力パラメータエラー /会社 ྡカナ桁数超過",
-    "en": "Input parameter error / URL3 format invalid"
-  },
-  "M01363001": {
-    "ja": "入力パラメータエラー /代表者姓未指定",
-    "en": "Input parameter error / PR digit number excess"
-  },
-  "M01363005": {
-    "ja": "入力パラメータエラー /代表者姓桁数超過",
-    "en": "Input parameter error / Closing date format incorrect"
-  },
-  "M01364001": {
-    "ja": "入力パラメータエラー /代表者 ྡ未指定",
-    "en": "Input parameter error / Payment method format incorrect"
-  },
-  "M01364005": {
-    "ja": "入力パラメータエラー /代表者 ྡ桁数超過",
-    "en": "Input parameter error / representative 者 number of digits excess"
-  },
-  "M01365001": {
-    "ja": "入力パラメータエラー /代表者姓カナ未指定",
-    "en": "Input parameter error / Representative surname Kana not specified"
-  },
-  "M01365005": {
-    "ja": "入力パラメータエラー /代表者姓カナ桁数超過",
-    "en": "Input parameter error / representative surname surpasses kana digit number excess"
-  },
-  "M01366001": {
-    "ja": "入力パラメータエラー /代表社 ྡカナ未指定",
-    "en": "Input parameter error / Representative company ྡ Kana not specified"
-  },
-  "M01366005": {
-    "ja": "入力パラメータエラー /代表社 ྡカナ桁数超過",
-    "en": "Input parameter error / Representative company ྡ Kana digit number excess"
-  },
-  "M01367001": {
-    "ja": "入力パラメータエラー /郵便番号未指定",
-    "en": "Input parameter error / Zip code not specified"
-  },
-  "M01367008": {
-    "ja": "入力パラメータエラー /郵便番号書式不正",
-    "en": "Input parameter error / Incorrect postal code format"
-  },
-  "M01368001": {
-    "ja": "入力パラメータエラー /都道府県未指定",
-    "en": "Input parameter error / Unspecified state"
-  },
-  "M01368005": {
-    "ja": "入力パラメータエラー /都道府県桁数超過",
-    "en": "Input parameter error / State digit excess"
-  },
-  "M01369001": {
-    "ja": "入力パラメータエラー /市区町村未指定",
-    "en": "Input parameter error / city not specified"
-  },
-  "M01369005": {
-    "ja": "入力パラメータエラー /市区町村桁数超過",
-    "en": "Input parameter error / municipality number of digits excess"
-  },
-  "M01370001": {
-    "ja": "入力パラメータエラー/町ྡ・番地未指定",
-    "en": "Input parameter error / Street address / address not specified"
-  },
-  "M01370005": {
-    "ja": "入力パラメータエラー/町ྡ・番地桁数超過",
-    "en": "Input parameter error / Town square · Address digit excess"
-  },
-  "M01371005": {
-    "ja": "入力パラメータエラー/ビル・マンションྡ桁数超過",
-    "en": "Input parameter error / Building · apartment ྡ digit number excess"
-  },
-  "M01372005": {
-    "ja": "入力パラメータエラー /部署 ྡ / 支店ྡ桁数超過",
-    "en": "Input parameter error / department ྡ / branch 超過 digit excess"
-  },
-  "M01373001": {
-    "ja": "入力パラメータエラー /担当者姓未指定",
-    "en": "Input parameter error / Contact person surname not specified"
-  },
-  "M01373005": {
-    "ja": "入力パラメータエラー /担当者姓桁数超過",
-    "en": "Input parameter error / Contact person surname digit number excess"
-  },
-  "M01374001": {
-    "ja": "入力パラメータエラー /担当者 ྡ未指定",
-    "en": "Input parameter error / person in charge ྡ not specified"
-  },
-  "M01374005": {
-    "ja": "入力パラメータエラー /担当者 ྡ桁数超過",
-    "en": "Input parameter error / person in charge ྡ digit number excess"
-  },
-  "M01375001": {
-    "ja": "入力パラメータエラー /担当者姓カナ未指定",
-    "en": "Input parameter error / Contact person surname Kana not specified"
-  },
-  "M01375005": {
-    "ja": "入力パラメータエラー /担当者姓カナ桁数超過",
-    "en": "Input parameter error / Contact person surname Kana digit number excess"
-  },
-  "M01376001": {
-    "ja": "入力パラメータエラー /担当者 ྡカナ未指定",
-    "en": "Input parameter error / person in charge 未 Kana not specified"
-  },
-  "M01376005": {
-    "ja": "入力パラメータエラー /担当者 ྡカナ桁数超過",
-    "en": "Input parameter error / person in charge ྡ Kana digit number excess"
-  },
-  "M01377001": {
-    "ja": "入力パラメータエラー /電話番号未指定",
-    "en": "Input parameter error / No phone number specified"
-  },
-  "M01377008": {
-    "ja": "入力パラメータエラー /電話番号書式不正",
-    "en": "Input parameter error / Invalid telephone number format"
-  },
-  "M01378008": {
-    "ja": "入力パラメータエラー /FAX番号書式不正",
-    "en": "Input parameter error / Incorrect fax number format"
-  },
-  "M01379008": {
-    "ja": "入力パラメータエラー /携帯電話番号書式不正",
-    "en": "Input parameter error / Invalid mobile phone number format"
-  },
-  "M01380001": {
-    "ja": "入力パラメータエラー /メールアドレス未指定",
-    "en": "Input parameter error / Representative company ྡ Kana digit number excess"
-  },
-  "M01380005": {
-    "ja": "入力パラメータエラー /メールアドレス桁数超過",
-    "en": "Input parameter error / Zip code not specified"
-  },
-  "M01380008": {
-    "ja": "入力パラメータエラー /メールアドレス書式不正",
-    "en": "Input parameter error / E-mail address format invalid"
-  },
-  "M01381008": {
-    "ja": "入力パラメータエラー/締め日書式不正",
-    "en": "Input parameter error / Closing date format incorrect"
-  },
-  "M01382008": {
-    "ja": "入力パラメータエラー /お支払い方法書式不正",
-    "en": "Input parameter error / Payment method format incorrect"
-  },
-  "M01383006": {
-    "ja": "入力パラメータエラー /設立年月（年）数値以外",
-    "en": "Input parameter error / Date of establishment (not yearly)"
-  },
-  "M01383011": {
-    "ja": "入力パラメータエラー/設立年月（年）範囲外",
-    "en": "Input parameter error / out of range of establishment date (year)"
-  },
-  "M01384006": {
-    "ja": "入力パラメータエラー /設立年月（月）数値以外",
-    "en": "Input parameter error / Other than establishment date (month)"
-  },
-  "M01384011": {
-    "ja": "入力パラメータエラー /設立年月（月）範囲外",
-    "en": "Input parameter error / out of range of establishment date (month)"
-  },
-  "M01385006": {
-    "ja": "入力パラメータエラー /年商数値以外",
-    "en": "Input parameter error / Other than year quotient"
-  },
-  "M01385011": {
-    "ja": "入力パラメータエラー /年商範囲外",
-    "en": "Input parameter error / out of year quotient range"
-  },
-  "M01386006": {
-    "ja": "入力パラメータエラー /業種番号数値以外",
-    "en": "Input parameter error / Other than industry number"
-  },
-  "M01386011": {
-    "ja": "入力パラメータエラー /業種番号範囲外",
-    "en": "Input parameter error / industry number out of range"
-  },
-  "M01387005": {
-    "ja": "入力パラメータエラー /取り扱いブランド/商品桁数超過",
-    "en": "Input parameter error / Handling brand / excess of product digits"
-  },
-  "M01388006": {
-    "ja": "入力パラメータエラー /店舗数数値以外",
-    "en": "Input parameter error / Other than the number of stores"
-  },
-  "M01388011": {
-    "ja": "入力パラメータエラー /店舗数範囲外",
-    "en": "Input parameter error / Number of stores out of range"
-  },
-  "M01389005": {
-    "ja": "入力パラメータエラー/URL1桁数超過",
-    "en": "Input parameter error / URL one digit excess"
-  },
-  "M01389008": {
-    "ja": "入力パラメータエラー/URL1書式不正",
-    "en": "Input parameter error / Invalid URL1 format"
-  },
-  "M01390005": {
-    "ja": "入力パラメータエラー/URL2桁数超過",
-    "en": "Input parameter error / URL 2 digits excess"
-  },
-  "M01390008": {
-    "ja": "入力パラメータエラー/URL2書式不正",
-    "en": "Input parameter error / URL2 format invalid"
-  },
-  "M01391005": {
-    "ja": "入力パラメータエラー/URL3桁数超過",
-    "en": "Input parameter error / URL 3 digits excess"
-  },
-  "M01391008": {
-    "ja": "入力パラメータエラー/URL3書式不正",
-    "en": "Input parameter error / URL3 format invalid"
-  },
-  "M01392005": {
-    "ja": "入力パラメータエラー /PR桁数超過",
-    "en": "Input parameter error / PR digit number excess"
-  },
-  "M01500001": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01500005": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01500012": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01510001": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01510005": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01510012": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01520002": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01530001": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01530005": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01540005": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01550001": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01550005": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01550006": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01590005": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01590006": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01600001": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01600005": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01600012": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01610005": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01610006": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01620005": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01620006": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01630010": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01640010": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01650012": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01660013": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01670013": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01680001": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01680008": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01690001": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01690002": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01690003": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01700001": {
-    "ja": "メールリンク決済呼び出しエラー/設定を確認してください。",
-    "en": "System error 2"
-  },
-  "M01701002": {
-    "ja": "メールリンク決済呼び出しエラー/設定を確認してください。",
-    "en": "System error 2"
-  },
-  "M01702003": {
-    "ja": "リンク決済呼び出しエラー/設定を確認してください。",
-    "en": "Please ask for input parameter error / re-input."
-  },
-  "M01703001": {
-    "ja": "メールリンク決済呼び出しエラー/設定を確認してください。",
-    "en": "System error 2"
-  },
-  "M01703005": {
-    "ja": "メールリンク決済呼び出しエラー/設定を確認してください。",
-    "en": "System error 2"
-  },
-  "M01704005": {
-    "ja": "メールリンク決済呼び出しエラー/設定を確認してください。",
-    "en": "System error 2"
-  },
-  "M01704006": {
-    "ja": "メールリンク決済呼び出しエラー/設定を確認してください。",
-    "en": "System error 2"
-  },
-  "M11010099": {
-    "ja": "取引エラー/決済を中止して、取引が出来ない஦を通知して下さい。",
-    "en": "Locale validity error"
-  },
-  "M11010999": {
-    "ja": "取引エラー/既に取引が完了している可能性があります。",
-    "en": "Please stop the member store setting error / settlement and check the setting status of the net bank by asking."
-  },
-  "M91099999": {
-    "ja": "システムエラー/取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
-    "en": "System error 3"
-  },
-  "N01001001": {
-    "ja": "通知コードエラー",
-    "en": "[Settlement request] An error occurred in au Easy OpenID linkage cancellation."
-  },
-  "N01001002": {
-    "ja": "取引存在エラー",
-    "en": "[Operation cancellation] The lady canceled the payment by au easy settlement."
-  },
-  "N01001003": {
-    "ja": "஧重受信エラー",
-    "en": "It is a transaction without permission to execute."
-  },
-  "N01001004": {
-    "ja": "状態エラー",
-    "en": "Not a valid user."
-  },
-  "N01001005": {
-    "ja": "利用停止エラー",
-    "en": "Authorization cancellation has been performed."
-  },
-  "N01001006": {
-    "ja": "金額不一致エラー",
-    "en": "Sales cancellation is taking place."
-  },
-  "N01001007": {
-    "ja": "税送料不一致エラー",
-    "en": "The amount of money exceeds the limit."
-  },
-  "N01001008": {
-    "ja": "決済処理日付エラー",
-    "en": "It is not a valid credit card."
-  },
-  "N01001009": {
-    "ja": "決済処理日付エラー",
-    "en": "It is not a valid credit card."
-  },
-  "N0C030C01": {
-    "ja": "CAFISセンタにて受付を拒否しました。",
-    "en": "A system error has occurred at the subsequent center."
-  },
-  "N0C030C03": {
-    "ja": "CAFISセンタにて受付を拒否しました。",
-    "en": "A system error has occurred at the subsequent center."
-  },
-  "N0C030C12": {
-    "ja": "カード会社にて受付を拒否しました。",
-    "en": "[Settlement request] Cancel processing has failed at the subsequent settlement center."
-  },
-  "N0C030C13": {
-    "ja": "カード会社にて受付を拒否しました。",
-    "en": "[Settlement request] Cancel processing has failed at the subsequent settlement center."
-  },
-  "N0C030C14": {
-    "ja": "カード会社にて受付を拒否しました。",
-    "en": "[Settlement request] Cancel processing has failed at the subsequent settlement center."
-  },
-  "N0C030C15": {
-    "ja": "CAFISセンタにて受付を拒否しました。",
-    "en": "A system error has occurred at the subsequent center."
-  },
-  "N0C030C16": {
-    "ja": "CAFISセンタにて受付を拒否しました。",
-    "en": "A system error has occurred at the subsequent center."
-  },
-  "N0C030C33": {
-    "ja": "CAFISセンタにて受付を拒否しました。",
-    "en": "A system error has occurred at the subsequent center."
-  },
-  "N0C030C34": {
-    "ja": "CAFISセンタにて受付を拒否しました。",
-    "en": "A system error has occurred at the subsequent center."
-  },
-  "N0C030C49": {
-    "ja": "CAFISセンタにて受付を拒否しました。",
-    "en": "A system error has occurred at the subsequent center."
-  },
-  "N0C030C50": {
-    "ja": "CAFISセンタにて受付を拒否しました。",
-    "en": "A system error has occurred at the subsequent center."
-  },
-  "N0C030C51": {
-    "ja": "CAFISセンタにて受付を拒否しました。",
-    "en": "A system error has occurred at the subsequent center."
-  },
-  "N0C030C53": {
-    "ja": "CAFISセンタにて受付を拒否しました。",
-    "en": "A system error has occurred at the subsequent center."
-  },
-  "N0C030C54": {
-    "ja": "CAFISセンタにて受付を拒否しました。",
-    "en": "A system error has occurred at the subsequent center."
-  },
-  "N0C030C55": {
-    "ja": "CAFISセンタにて受付を拒否しました。",
-    "en": "A system error has occurred at the subsequent center."
-  },
-  "N0C030C56": {
-    "ja": "CAFISセンタにて受付を拒否しました。",
-    "en": "A system error has occurred at the subsequent center."
-  },
-  "N0C030C57": {
-    "ja": "CAFISセンタにて受付を拒否しました。",
-    "en": "A system error has occurred at the subsequent center."
-  },
-  "N0C030C58": {
-    "ja": "CAFISセンタにて受付を拒否しました。",
-    "en": "A system error has occurred at the subsequent center."
-  },
-  "N0C030C60": {
-    "ja": "CAFISセンタにて受付を拒否しました。",
-    "en": "A system error has occurred at the subsequent center."
-  },
-  "N0C030G03": {
-    "ja": "カード会社にて受付を拒否しました。",
-    "en": "[Settlement request] Cancel processing has failed at the subsequent settlement center."
-  },
-  "N0C030G12": {
-    "ja": "カード会社にて受付を拒否しました。",
-    "en": "[Settlement request] Cancel processing has failed at the subsequent settlement center."
-  },
-  "N0C030G30": {
-    "ja": "カード会社にて受付を拒否しました。",
-    "en": "[Settlement request] Cancel processing has failed at the subsequent settlement center."
-  },
-  "N0C030G54": {
-    "ja": "カード会社にて受付を拒否しました。",
-    "en": "[Settlement request] Cancel processing has failed at the subsequent settlement center."
-  },
-  "N0C030G55": {
-    "ja": "カード会社にて受付を拒否しました。",
-    "en": "[Settlement request] Cancel processing has failed at the subsequent settlement center."
-  },
-  "N0C030G56": {
-    "ja": "カード会社にて受付を拒否しました。",
-    "en": "[Settlement request] Cancel processing has failed at the subsequent settlement center."
-  },
-  "N0C030G60": {
-    "ja": "カード会社にて受付を拒否しました。",
-    "en": "[Settlement request] Cancel processing has failed at the subsequent settlement center."
-  },
-  "N0C030G61": {
-    "ja": "カード会社にて受付を拒否しました。",
-    "en": "[Settlement request] Cancel processing has failed at the subsequent settlement center."
-  },
-  "N0C030G65": {
-    "ja": "カード会社にて受付を拒否しました。",
-    "en": "[Settlement request] Cancel processing has failed at the subsequent settlement center."
-  },
-  "N0C030G67": {
-    "ja": "商品コードの入力が誤っていた場吅です。",
-    "en": "[Payment confirmation] Not a valid user."
-  },
-  "N0C030G83": {
-    "ja": "有効期限切れのクレジットカードが入力されて場吅です。",
-    "en": "Not a valid user."
-  },
-  "N0C030G85": {
-    "ja": "CAFISセンタにて契約がないカードが入力された場吅です。",
-    "en": "A processing cancellation error occurred at the following center, and a valid initial charge remained."
-  },
-  "N0C030G95": {
-    "ja": "クレジット会社センタの該当業務の運用が終了している場吅です。",
-    "en": "[Settlement request] Finalization has failed in the subsequent settlement center."
-  },
-  "N0C030G96": {
-    "ja": "カード会社にて受付を拒否しました。",
-    "en": "[Settlement request] Cancel processing has failed at the subsequent settlement center."
-  },
-  "N0C030G97": {
-    "ja": "カード会社にて受付を拒否しました。",
-    "en": "[Settlement request] Cancel processing has failed at the subsequent settlement center."
-  },
-  "N0C030G98": {
-    "ja": "接続されたクレジット会社センタの対象業務ではない場吅です。",
-    "en": "[Cancellation request] Cancellation processing failed in the subsequent settlement center."
-  },
-  "N0C030G99": {
-    "ja": "接続要求仕向センタに対し、受付拒否の場吅です。",
-    "en": "[Settlement Canceled] Princess has canceled docomo Keitai."
-  },
-  "N0K040026": {
-    "ja": "認証支援センタからの決済通知に対する応答が不正です。",
-    "en": "[Cancellation request, settlement cancellation] Mr. Softbank collectively canceled payment (B) or cancellation processing failed."
-  },
-  "N0K040027": {
-    "ja": "認証支援センタからの決済通知に対する応答が不正です。",
-    "en": "[Cancellation request, settlement cancellation] Mr. Softbank collectively canceled payment (B) or cancellation processing failed."
-  },
-  "N0K040028": {
-    "ja": "認証支援センタからの決済通知に対する応答が不正です。",
-    "en": "[Cancellation request, settlement cancellation] Mr. Softbank collectively canceled payment (B) or cancellation processing failed."
-  },
-  "N0K040029": {
-    "ja": "認証支援センタで条件付正常を受け取りました。既に決済が完了しているお取引に対して再度決済を行なった場吅です。",
-    "en": "[Payment failure] Softbank collectively payment (B) failed."
-  },
-  "N0K040037": {
-    "ja": "SSLサーバ証明書認証エラーの場吅です。",
-    "en": "[Payment failure] Settlement failed in the subsequent settlement center."
-  },
-  "N0N010007": {
-    "ja": "ネット決済サービス非対応の携帯電話の場吅です。",
-    "en": "[Payment failure] DOCOMO mobile phone payment has failed."
-  },
-  "N0N010008": {
-    "ja": "ネット決済サービス非対応の携帯電話の場吅です。",
-    "en": "[Payment failure] DOCOMO mobile phone payment has failed."
-  },
-  "N0N010009": {
-    "ja": "ネット決済サービス非対応の携帯電話の場吅です。",
-    "en": "[Payment failure] DOCOMO mobile phone payment has failed."
-  },
-  "N0N010013": {
-    "ja": "加盟店契約期間外の場吅です。",
-    "en": "[Settlement Canceled] Mr. Lady has canceled the application for docomo continuous billing."
-  },
-  "N0N010024": {
-    "ja": "認証支援センタに接続できない場吅です。",
-    "en": "[Cancel change] Mr. Lady has canceled the change of docomo continuous billing."
-  },
-  "N0N010032": {
-    "ja": "加盟店ྡに絵文字が指定され、絵文字変換用文字列がバイナリ変換できない場吅です。",
-    "en": "[Stop Cancel] Mr. Lady has canceled the end of DOCOMO continuous billing."
-  },
-  "N0N020014": {
-    "ja": "処理継続期間がオーバーした場吅です。",
-    "en": "[Payment failure] The application for DOCOMO continuous billing has failed."
-  },
-  "N0N020017": {
-    "ja": "有効期限切れのクレジットカードが入力された場吅です。",
-    "en": "[Failed to change] Change of DOCOMO continuous charge has failed."
-  },
-  "N0N020018": {
-    "ja": "カード会社の都吅によりお取扱できないクレジットカードが入力された場吅です。",
-    "en": "[Failed to finish] The end of DOCOMO continuous billing has failed."
-  },
-  "N0N020019": {
-    "ja": "カード会社の都吅によりお取扱できないクレジットカードが入力された場吅です。",
-    "en": "[Failed to finish] The end of DOCOMO continuous billing has failed."
-  },
-  "N0N020020": {
-    "ja": "カード会社の都吅によりお取扱できないクレジットカードが入力された場吅です。",
-    "en": "[Failed to finish] The end of DOCOMO continuous billing has failed."
-  },
-  "N0N020021": {
-    "ja": "カード会社の都吅によりお取扱できないクレジットカードが入力された場吅です。",
-    "en": "[Failed to finish] The end of DOCOMO continuous billing has failed."
-  },
-  "N0N020022": {
-    "ja": "カード会社の都吅によりお取扱できないクレジットカードが入力された場吅です。",
-    "en": "[Failed to finish] The end of DOCOMO continuous billing has failed."
-  },
-  "N0N020023": {
-    "ja": "カード会社の都吅によりお取扱できないクレジットカードが入力された場吅です。",
-    "en": "[Failed to finish] The end of DOCOMO continuous billing has failed."
-  },
-  "N0N030038": {
-    "ja": "お宠様が入力した暗証番号が誤っていた場吅です。",
-    "en": "[Increase request] In the subsequent settlement center, increase processing has failed."
-  },
-  "N0N040014": {
-    "ja": "処理継続期間がオーバーした場吅です。",
-    "en": "[Payment failure] The application for DOCOMO continuous billing has failed."
-  },
-  "N0N040031": {
-    "ja": "認証支援センタに接続できない場吅です。",
-    "en": "[Cancel change] Mr. Lady has canceled the change of docomo continuous billing."
-  },
-  "N0T000001": {
-    "ja": "Felica処理中にエラーが発生した場吅、または、認証支援センタに接続できない場吅、または、決済の内容を確認し、実行せずに戻るを選択した場吅です。",
-    "en": "[Settlement cancellation] Mr. Ohjima has canceled the bank settlement."
-  },
-  "N0T000002": {
-    "ja": "iDアプリのエリア発行が完了していません。",
-    "en": "[Settlement Failure] Settlement failed due to a discrepancy in the settlement at the subsequent settlement center."
-  },
-  "N0T000003": {
-    "ja": "ご利用可能なカードがありません。",
-    "en": "[Payment failure] Settlement failed due to an unknown error at the subsequent settlement center."
-  },
-  "N0T000004": {
-    "ja": "パスワード入力間違いが既定回数を超えたため、iDでお支払が出来ません。",
-    "en": "[Payment failure] An unexpected error code has been returned."
-  },
-  "N0T000005": {
-    "ja": "ICカードロックがかかっているか、通信中に何かしらの以上が発生した可能性があります。",
-    "en": "Insufficient funds"
-  },
-  "N0T000006": {
-    "ja": "前回処理した処理番号とྠじ処理番号です。",
-    "en": "Over payment amount"
-  },
-  "N0T000007": {
-    "ja": "カード情報の読み込みに失敗した場吅です。",
-    "en": "Not activated"
-  },
-  "N0T000008": {
-    "ja": "ネット決済の処理中に他の処理でFelicaチップが更新されました。",
-    "en": "Before start of use"
-  },
-  "N0T000009": {
-    "ja": "お取扱できないクレジットカードが選択された場吅です。",
-    "en": "Authentication number error"
-  },
-  "N0T000010": {
-    "ja": "認証支援センタに接続できない場吅、または、 iDアプリのバージョンアップが必要な場吅です。",
-    "en": "Invalid card"
-  },
-  "N10000001": {
-    "ja": "取引存在エラー",
-    "en": "[Operation cancellation] The lady canceled the payment by au easy settlement."
-  },
-  "NC1000001": {
-    "ja": "取引IDチェックエラー",
-    "en": "Input parameter error / card number not specified"
-  },
-  "NC1000002": {
-    "ja": "取引の存在チェックエラー",
-    "en": "Input parameter error / card number digit excess"
-  },
-  "NC1000003": {
-    "ja": "トークンチェックエラー",
-    "en": "Input parameter error / Card number digit range invalid"
-  },
-  "NC1000004": {
-    "ja": "状態遷移チェックエラー(入金済み)",
-    "en": "Input parameter error / other than card number value"
-  },
-  "NC1000005": {
-    "ja": "状態遷移チェックエラー(期限切れ)",
-    "en": "Input parameter error / card expiration date not specified"
-  },
-  "NC1000006": {
-    "ja": "状態遷移チェックエラー (不正な遷移)",
-    "en": "Input parameter error / card expiration date exceeded"
-  },
-  "NC1000007": {
-    "ja": "有効期限切れ",
-    "en": "Input parameter error / other than card expiration date"
-  },
-  "NC1000008": {
-    "ja": "状態遷移エラー",
-    "en": "Input parameter error / Execution mode digit number excess"
-  },
-  "NC1000009": {
-    "ja": "決済NG",
-    "en": "Input parameter error / billing information presence judgment flag incorrect format"
-  },
-  "NC1000010": {
-    "ja": "MD5チェックエラー",
-    "en": "Input parameter error / User ID digit number excess"
-  },
-  "NC1000011": {
-    "ja": "決済情報取得エラー",
-    "en": "Input parameter error / card number of digits exceeded"
-  },
-  "NC1000012": {
-    "ja": "決済結果パラメータチェックエラー(決済結果に対しての決済日時の有無)",
-    "en": "Input parameter error / card definition incorrect format"
-  },
-  "NC1000013": {
-    "ja": "購入情報内容チェックエラー時URLへ遷移",
-    "en": "Input parameter error / billing customer's last digit exceeded"
-  },
-  "NC2000001": {
-    "ja": "決済の不整合(決済が失敗した取引に対しての結果通知)",
-    "en": "Input parameter error / billing customer address exceeded one digit"
-  },
-  "NC2000002": {
-    "ja": "ショップ特定不可",
-    "en": "Input parameter error / billing customer address exceeded 2 digits"
-  },
-  "NC2000003": {
-    "ja": "SCD未設定",
-    "en": "Input parameter error / billing customer address exceeded 3 digits"
-  },
-  "NC2000005": {
-    "ja": "利用停止チェックエラー",
-    "en": "Input parameter error / billing customer exceeding prefecture digit number"
-  },
-  "NC2000006": {
-    "ja": "紐づく取引が存在しない(購入情報出力)",
-    "en": "Input parameter error / billing customer postal code excess digits"
-  },
-  "NC2000007": {
-    "ja": "紐づく取引が存在しない(決済結果通知)",
-    "en": "Input parameter error / billing customer postal code format incorrect"
-  },
-  "P01010202": {
-    "ja": "取引数が月間の最大数を超えています。",
-    "en": "Specified option is invalid."
-  },
-  "P01010400": {
-    "ja": "注文吅計が不正です。",
-    "en": "Specified parameters are not supported."
-  },
-  "P01010401": {
-    "ja": "注文吅計が不正です。",
-    "en": "Specified parameters are not supported."
-  },
-  "P01010402": {
-    "ja": "加盟店の設定が認証オプションを使用できない契約になっています。",
-    "en": "Invalid data."
-  },
-  "P01010404": {
-    "ja": "戻りURLが不正です。",
-    "en": "The buyer's balance is insufficient."
-  },
-  "P01010405": {
-    "ja": "キャンセル時のURLが不正です。",
-    "en": "The risk management configuration has rejected the transaction."
-  },
-  "P01010406": {
-    "ja": "顧宠IDが無効です。",
-    "en": "The payment was declined due to the risk management settings."
-  },
-  "P01010407": {
-    "ja": "顧宠のメールアドレスが無効です。",
-    "en": "Approval has been cancelled."
-  },
-  "P01010408": {
-    "ja": "トークンが不正です。",
-    "en": "The approval period has expired."
-  },
-  "P01010409": {
-    "ja": "トークンが不正です。",
-    "en": "The approval period has expired."
-  },
-  "P01010410": {
-    "ja": "トークンが無効です。",
-    "en": "Approval has already been completed."
-  },
-  "P01010411": {
-    "ja": "トークンの有効期限が切れました。",
-    "en": "The customer account has been restricted."
-  },
-  "P01010412": {
-    "ja": "請求番号が重複しています。",
-    "en": "We can not continue the approval process."
-  },
-  "P01010413": {
-    "ja": "商品の吅計金額が不正です。",
-    "en": "Unsupported currency code."
-  },
-  "P01010414": {
-    "ja": "取引の金額上限を超えています。",
-    "en": "The transaction has been rejected."
-  },
-  "P01010415": {
-    "ja": "指定取引は処理済みです。",
-    "en": "The approval and withdrawal functions can not be used."
-  },
-  "P01010416": {
-    "ja": "再処理の最大試行回数を超えています。",
-    "en": "Transaction ID is invalid."
-  },
-  "P01010417": {
-    "ja": "支払方法が無効です。",
-    "en": "The specified amount of money has exceeded the limit."
-  },
-  "P01010418": {
-    "ja": "通貨コードが不正です。",
-    "en": "The merchant setting is a contract that can not use the approval and withdrawal functions."
-  },
-  "P01010419": {
-    "ja": "顧宠IDが不正です。",
-    "en": "The maximum number available for settlement has been reached."
-  },
-  "P01010420": {
-    "ja": "支払オプションが不正です。",
-    "en": "The cancellation approval number is incorrect."
-  },
-  "P01010421": {
-    "ja": "トークンが無効です。",
-    "en": "Approval has already been completed."
-  },
-  "P01010422": {
-    "ja": "顧宠の資金源が不正です。",
-    "en": "The specification method of re-approval is invalid."
-  },
-  "P01010424": {
-    "ja": "配送先住所が無効です。",
-    "en": "The maximum number of re-authorizations allowed for approval has been reached."
-  },
-  "P01010425": {
-    "ja": "加盟店の設定がAPIを使用できない契約になっています。",
-    "en": "A reapproval was called during the warranty period."
-  },
-  "P01010426": {
-    "ja": "商品の吅計金額が無効です。",
-    "en": "The transaction has been canceled or expired."
-  },
-  "P01010427": {
-    "ja": "送料の吅計が無効です。",
-    "en": "The status of the order is canceled, expired, or completed."
-  },
-  "P01010428": {
-    "ja": "手数料の吅計が無効です。",
-    "en": "Your order has expired."
-  },
-  "P01010429": {
-    "ja": "税金の吅計が無効です。",
-    "en": "Your order has been cancelled."
-  },
-  "P01010430": {
-    "ja": "商品金額が不正です。",
-    "en": "The maximum number of approvals allowed for the order has been reached."
-  },
-  "P01010431": {
-    "ja": "商品金額が無効です。",
-    "en": "The transaction has been rejected by the risk model."
-  },
-  "P01010432": {
-    "ja": "請求番号の桁数オーバーです。",
-    "en": "Unsupported parameter."
-  },
-  "P01010433": {
-    "ja": "商品説明の一部が省略されました。",
-    "en": "The shipping address is incorrect."
-  },
-  "P01010434": {
-    "ja": "自由項目の一部が省略されました。",
-    "en": "Failed to query shipping address."
-  },
-  "P01010435": {
-    "ja": "承認が未処理です。",
-    "en": "Number of digits is over."
-  },
-  "P01010436": {
-    "ja": "ページスタイルྡの桁数オーバーです。",
-    "en": "You can not cancel designated approval, reapprove, or collect."
-  },
-  "P01010437": {
-    "ja": "ヘッダーイメージURLの桁数オーバーです。",
-    "en": "Your billing address is incorrect."
-  },
-  "P01010438": {
-    "ja": "ヘッダーイメージURLの桁数オーバーです。",
-    "en": "Your billing address is incorrect."
-  },
-  "P01010439": {
-    "ja": "ヘッダーイメージURLの桁数オーバーです。",
-    "en": "Your billing address is incorrect."
-  },
-  "P01010440": {
-    "ja": "ヘッダーイメージURLの桁数オーバーです。",
-    "en": "Your billing address is incorrect."
-  },
-  "P01010441": {
-    "ja": "通知先URLの桁数オーバーです。",
-    "en": "Payment is pending."
-  },
-  "P01010442": {
-    "ja": "識別コードの桁数オーバーです。",
-    "en": "The transaction has been cancelled."
-  },
-  "P01010443": {
-    "ja": "支払オプションが不正です。",
-    "en": "The cancellation approval number is incorrect."
-  },
-  "P01010444": {
-    "ja": "通貨コードが不正です。",
-    "en": "The merchant setting is a contract that can not use the approval and withdrawal functions."
-  },
-  "P01010445": {
-    "ja": "指定取引の処理を続行できません。",
-    "en": "I can not continue to process the transaction."
-  },
-  "P01010446": {
-    "ja": "支払オプションが不正です。",
-    "en": "The cancellation approval number is incorrect."
-  },
-  "P01010457": {
-    "ja": "eBayのAPIの初期化に失敗しました。",
-    "en": "Invalid option."
-  },
-  "P01010458": {
-    "ja": "eBayのAPIでエラーが発生しました。",
-    "en": "There is an error in the specification of the option."
-  },
-  "P01010459": {
-    "ja": "eBayのAPIでエラーが発生しました。",
-    "en": "There is an error in the specification of the option."
-  },
-  "P01010460": {
-    "ja": "eBayの通信でエラーが発生しました。",
-    "en": "Number of digits in URL is over."
-  },
-  "P01010461": {
-    "ja": "商品数が不正です。",
-    "en": "Payment failed due to hold status."
-  },
-  "P01010462": {
-    "ja": "注文が存在しません。",
-    "en": "The transaction has been returned because an error occurred."
-  },
-  "P01010463": {
-    "ja": "eBayの接続情報が不正です。",
-    "en": "The item amounts do not match."
-  },
-  "P01010464": {
-    "ja": "商品番号と取引IDが不整吅です。",
-    "en": "The payment status is incorrect. (None)"
-  },
-  "P01010465": {
-    "ja": "eBayの接続情報が無効です。",
-    "en": "The payment status is incorrect. (Canceled-Reversal)"
-  },
-  "P01010467": {
-    "ja": "商品番号が重複しています。",
-    "en": "The payment status is incorrect. (Denied)"
-  },
-  "P01010468": {
-    "ja": "注文IDが重複しています。",
-    "en": "The payment status is incorrect. (Expired)"
-  },
-  "P01010469": {
-    "ja": "指定オプションが一時的に使用不可になっています。",
-    "en": "The payment status is incorrect. (Failed)"
-  },
-  "P01010470": {
-    "ja": "指定オプションが無効です。",
-    "en": "The payment status is incorrect. (In-Progress)"
-  },
-  "P01010471": {
-    "ja": "戻りURLが不正です。",
-    "en": "The buyer's balance is insufficient."
-  },
-  "P01010472": {
-    "ja": "キャンセル時のURLが不正です。",
-    "en": "The risk management configuration has rejected the transaction."
-  },
-  "P01010473": {
-    "ja": "指定パラメータはサポート対象外です。",
-    "en": "The payment status is incorrect. (Partially-Refunded)"
-  },
-  "P01010474": {
-    "ja": "指定取引の処理を続行できません。",
-    "en": "I can not continue to process the transaction."
-  },
-  "P01010475": {
-    "ja": "支払オプションが不正です。",
-    "en": "The cancellation approval number is incorrect."
-  },
-  "P01010476": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01010477": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01010478": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01010479": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01010480": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01010481": {
-    "ja": "支払オプションが不正です。",
-    "en": "The cancellation approval number is incorrect."
-  },
-  "P01010482": {
-    "ja": "支払オプションが不正です。",
-    "en": "The cancellation approval number is incorrect."
-  },
-  "P01010486": {
-    "ja": "購入者の残高が不足しています。",
-    "en": "The payment status is incorrect. (Refunded)"
-  },
-  "P01010537": {
-    "ja": "リスク管理設定により、該当取引が拒否されました。",
-    "en": "The payment status is incorrect. (Reversed)"
-  },
-  "P01010538": {
-    "ja": "リスク管理設定により、該当取引が拒否されました。",
-    "en": "The payment status is incorrect. (Reversed)"
-  },
-  "P01010539": {
-    "ja": "リスク管理設定により、支払いが拒否されました。",
-    "en": "The payment status is incorrect. (Processed)"
-  },
-  "P01010600": {
-    "ja": "承認が取消されました。",
-    "en": "The payment status is incorrect. (Voided)"
-  },
-  "P01010601": {
-    "ja": "承認期間の有効期限が切れました。",
-    "en": "The payment status is incorrect."
-  },
-  "P01010602": {
-    "ja": "承認は既に完了しています。",
-    "en": "Invalid parameter."
-  },
-  "P01010603": {
-    "ja": "顧宠のアカウントに制限が掛けられています。",
-    "en": "Specified method is not supported."
-  },
-  "P01010604": {
-    "ja": "承認処理を続行できません。",
-    "en": "No method has been specified."
-  },
-  "P01010605": {
-    "ja": "サポート対象外の通貨コードです。",
-    "en": "Request parameter is not specified."
-  },
-  "P01010606": {
-    "ja": "取引が拒否されました。",
-    "en": "Parameter is not specified. (Amt)"
-  },
-  "P01010607": {
-    "ja": "承認と回収機能が使用できません。",
-    "en": "Parameter is not specified. (MaxAmt)"
-  },
-  "P01010608": {
-    "ja": "顧宠の資金源が不正です。",
-    "en": "The specification method of re-approval is invalid."
-  },
-  "P01010609": {
-    "ja": "取引IDが無効です。",
-    "en": "Parameter is not specified. (ReturnURL)"
-  },
-  "P01010610": {
-    "ja": "指定された金額の上限を超えています。",
-    "en": "Parameter is not specified. (NotifyURL)"
-  },
-  "P01010611": {
-    "ja": "加盟店の設定が承認と回収機能を使用できない契約になっています。",
-    "en": "Parameter is not specified. (CancelURL)"
-  },
-  "P01010612": {
-    "ja": "決済可能な最大数に達しました。",
-    "en": "Parameter is not specified. (ShipToStreet)"
-  },
-  "P01010613": {
-    "ja": "通貨コードが不正です。",
-    "en": "The merchant setting is a contract that can not use the approval and withdrawal functions."
-  },
-  "P01010614": {
-    "ja": "取消の承認番号が不正です。",
-    "en": "Parameter is not specified. (ShipToStreet2)"
-  },
-  "P01010615": {
-    "ja": "再承認の指定方法が不正です。",
-    "en": "Parameter is not specified. (ShipToCity)"
-  },
-  "P01010616": {
-    "ja": "承認に許される再承認の最大数に達しました。",
-    "en": "Parameter is not specified. (ShipToState)"
-  },
-  "P01010617": {
-    "ja": "保証期間中に再承認が呼出されました。",
-    "en": "Parameter is not specified. (ShipToZip)"
-  },
-  "P01010618": {
-    "ja": "取引が取消、又は期限切れの状態です。",
-    "en": "Parameter is not specified. (Country)"
-  },
-  "P01010619": {
-    "ja": "請求番号の桁数オーバーです。",
-    "en": "Unsupported parameter."
-  },
-  "P01010620": {
-    "ja": "注文の状態が取消、期限切れ、又は完了状態です。",
-    "en": "Parameter is not specified. (ReqConfirmShipping)"
-  },
-  "P01010621": {
-    "ja": "注文の有効期限が切れました。",
-    "en": "Parameter is not specified. (No shipping)"
-  },
-  "P01010622": {
-    "ja": "注文が取消されました。",
-    "en": "Parameter is not specified. (AddrOverride)"
-  },
-  "P01010623": {
-    "ja": "注文に許される承認の最大数に達しました。",
-    "en": "Parameter is not specified. (LocaleCode)"
-  },
-  "P01010624": {
-    "ja": "請求番号が重複しています。",
-    "en": "We can not continue the approval process."
-  },
-  "P01010625": {
-    "ja": "取引の金額上限を超えています。",
-    "en": "The transaction has been rejected."
-  },
-  "P01010626": {
-    "ja": "取引がリスクモデルによって拒否されました。",
-    "en": "Parameter is not specified. (PaymentAction)"
-  },
-  "P01010627": {
-    "ja": "サポート対象外のパラメータです。",
-    "en": "Parameter is not specified. (Email)"
-  },
-  "P01010628": {
-    "ja": "指定取引の処理を続行できません。",
-    "en": "I can not continue to process the transaction."
-  },
-  "P01010629": {
-    "ja": "再承認の指定方法が不正です。",
-    "en": "Parameter is not specified. (ShipToCity)"
-  },
-  "P01010630": {
-    "ja": "商品金額が無効です。",
-    "en": "The transaction has been rejected by the risk model."
-  },
-  "P01010725": {
-    "ja": "配送先住所が不正です。",
-    "en": "Parameter is not specified. (Token)"
-  },
-  "P01010726": {
-    "ja": "配送先住所が不正です。",
-    "en": "Parameter is not specified. (Token)"
-  },
-  "P01010727": {
-    "ja": "配送先住所が不正です。",
-    "en": "Parameter is not specified. (Token)"
-  },
-  "P01010728": {
-    "ja": "配送先住所が不正です。",
-    "en": "Parameter is not specified. (Token)"
-  },
-  "P01010729": {
-    "ja": "配送先住所が不正です。",
-    "en": "Parameter is not specified. (Token)"
-  },
-  "P01010730": {
-    "ja": "配送先住所が不正です。",
-    "en": "Parameter is not specified. (Token)"
-  },
-  "P01010731": {
-    "ja": "配送先住所が不正です。",
-    "en": "Parameter is not specified. (Token)"
-  },
-  "P01010736": {
-    "ja": "配送先住所の照会に失敗しました。",
-    "en": "Parameter is not specified. (PayerID)"
-  },
-  "P01010800": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01011001": {
-    "ja": "桁数オーバーです。",
-    "en": "Parameter is not specified. (ItemAmt)"
-  },
-  "P01011094": {
-    "ja": "指定承認の取消、再承認、回収はできません。",
-    "en": "Parameter is not specified. (ShippingAmt)"
-  },
-  "P01011547": {
-    "ja": "指定オプションが一時的に使用不可になっています。",
-    "en": "The payment status is incorrect. (Failed)"
-  },
-  "P01011601": {
-    "ja": "請求先住所が不正です。",
-    "en": "Parameter is not specified. (HandlingAmt)"
-  },
-  "P01011602": {
-    "ja": "請求先住所が不正です。",
-    "en": "Parameter is not specified. (HandlingAmt)"
-  },
-  "P01011610": {
-    "ja": "支払が保留されています。",
-    "en": "Parameter is not specified. (TaxAmt)"
-  },
-  "P01011611": {
-    "ja": "取引が中止されました。",
-    "en": "Parameter is not specified. (IPAddress)"
-  },
-  "P01011612": {
-    "ja": "取引の処理を続行できません。",
-    "en": "Parameter is not specified. (ShipToName)"
-  },
-  "P01011801": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01011802": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01011803": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01011804": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01011805": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01011806": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01011807": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01011810": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01011811": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01011812": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01011813": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01011814": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01011815": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01011820": {
-    "ja": "無効なデータです。",
-    "en": "The payment status is incorrect. (Pending)"
-  },
-  "P01011821": {
-    "ja": "無効なオプションです。",
-    "en": "Parameter is not specified. (L_Amt)"
-  },
-  "P01011822": {
-    "ja": "オプションの指定に誤りがあります。",
-    "en": "Parameter is not specified. (L_TaxAmt)"
-  },
-  "P01011823": {
-    "ja": "オプションの指定に誤りがあります。",
-    "en": "Parameter is not specified. (L_TaxAmt)"
-  },
-  "P01011824": {
-    "ja": "オプションの指定に誤りがあります。",
-    "en": "Parameter is not specified. (L_TaxAmt)"
-  },
-  "P01011825": {
-    "ja": "オプションの指定に誤りがあります。",
-    "en": "Parameter is not specified. (L_TaxAmt)"
-  },
-  "P01011826": {
-    "ja": "送料の吅計が無効です。",
-    "en": "The status of the order is canceled, expired, or completed."
-  },
-  "P01011827": {
-    "ja": "オプションの指定に誤りがあります。",
-    "en": "Parameter is not specified. (L_TaxAmt)"
-  },
-  "P01011828": {
-    "ja": "オプションの指定に誤りがあります。",
-    "en": "Parameter is not specified. (L_TaxAmt)"
-  },
-  "P01011829": {
-    "ja": "オプションの指定に誤りがあります。",
-    "en": "Parameter is not specified. (L_TaxAmt)"
-  },
-  "P01011830": {
-    "ja": "オプションの指定に誤りがあります。",
-    "en": "Parameter is not specified. (L_TaxAmt)"
-  },
-  "P01011831": {
-    "ja": "URLの桁数オーバーです。",
-    "en": "Parameter is not specified. (AuthorizationID)"
-  },
-  "P01011832": {
-    "ja": "注文吅計が不正です。",
-    "en": "Specified parameters are not supported."
-  },
-  "P01012109": {
-    "ja": "無効なオプションです。",
-    "en": "Parameter is not specified. (L_Amt)"
-  },
-  "P01012124": {
-    "ja": "無効なオプションです。",
-    "en": "Parameter is not specified. (L_Amt)"
-  },
-  "P01012200": {
-    "ja": "顧宠IDが不正です。",
-    "en": "The maximum number available for settlement has been reached."
-  },
-  "P01012201": {
-    "ja": "オプションの指定に誤りがあります。",
-    "en": "Parameter is not specified. (L_TaxAmt)"
-  },
-  "P01012202": {
-    "ja": "オプションの指定に誤りがあります。",
-    "en": "Parameter is not specified. (L_TaxAmt)"
-  },
-  "P01012203": {
-    "ja": "保留状態の為、支払が失敗しました。",
-    "en": "Parameter is not specified. (CompleteType)"
-  },
-  "P01012204": {
-    "ja": "エラーが発生した為、取引は戻されました。",
-    "en": "Parameter is not specified. (CurrencyCode)"
-  },
-  "P01012205": {
-    "ja": "オプションの指定に誤りがあります。",
-    "en": "Parameter is not specified. (L_TaxAmt)"
-  },
-  "P01012206": {
-    "ja": "オプションの指定に誤りがあります。",
-    "en": "Parameter is not specified. (L_TaxAmt)"
-  },
-  "P01012207": {
-    "ja": "オプションの指定に誤りがあります。",
-    "en": "Parameter is not specified. (L_TaxAmt)"
-  },
-  "P01012208": {
-    "ja": "商品金額が一致しません。",
-    "en": "Parameter is not specified. (TransactionID)"
-  },
-  "P01020000": {
-    "ja": "支払状況が不正です。（None）",
-    "en": "Parameter is not specified. (TransactionEntity)"
-  },
-  "P01020001": {
-    "ja": "支払状況が不正です。（Canceled-Reversal）",
-    "en": "Parameter is not specified. (Acct)"
-  },
-  "P01020003": {
-    "ja": "支払状況が不正です。（Denied）",
-    "en": "Parameter is not specified. (ExpDate)"
-  },
-  "P01020004": {
-    "ja": "支払状況が不正です。（Expired）",
-    "en": "Parameter is not specified. (FirstName)"
-  },
-  "P01020005": {
-    "ja": "支払状況が不正です。（Failed）",
-    "en": "Parameter is not specified. (LastName)"
-  },
-  "P01020006": {
-    "ja": "支払状況が不正です。（In-Progress）",
-    "en": "Parameter is not specified. (Street)"
-  },
-  "P01020007": {
-    "ja": "支払状況が不正です。（Partially-Refunded）",
-    "en": "Parameter is not specified. (Street 2)"
-  },
-  "P01020008": {
-    "ja": "支払状況が不正です。（Pending）",
-    "en": "Parameter is not specified. (City)"
-  },
-  "P01020009": {
-    "ja": "支払状況が不正です。（Refunded）",
-    "en": "Parameter is not specified. (State)"
-  },
-  "P01020010": {
-    "ja": "支払状況が不正です。（Reversed）",
-    "en": "Parameter is not specified. (Zip)"
-  },
-  "P01020011": {
-    "ja": "支払状況が不正です。（Processed）",
-    "en": "Parameter is not specified. (CountryCode)"
-  },
-  "P01020012": {
-    "ja": "支払状況が不正です。（Voided）",
-    "en": "Parameter is not specified. (RefundType)"
-  },
-  "P01029999": {
-    "ja": "支払状況が不正です。",
-    "en": "Parameter is not specified. (StartDate)"
-  },
-  "P01081000": {
-    "ja": "無効なパラメータです。",
-    "en": "Parameter is not specified. (EndDate)"
-  },
-  "P01081001": {
-    "ja": "無効なパラメータです。",
-    "en": "Parameter is not specified. (EndDate)"
-  },
-  "P01081002": {
-    "ja": "指定メソッドはサポートされていません。",
-    "en": "Parameter is not specified. (MPID)"
-  },
-  "P01081003": {
-    "ja": "メソッドが指定されていません。",
-    "en": "Parameter is not specified. (CreditCardType)"
-  },
-  "P01081004": {
-    "ja": "リクエストパラメータが指定されていません。",
-    "en": "Parameter is not specified. (User)"
-  },
-  "P01081100": {
-    "ja": "パラメータが指定されていません。（Amt）",
-    "en": "Parameter is not specified. (Pwd)"
-  },
-  "P01081101": {
-    "ja": "パラメータが指定されていません。（MaxAmt）",
-    "en": "Parameter is not specified. (Version)"
-  },
-  "P01081102": {
-    "ja": "パラメータが指定されていません。（ReturnURL）",
-    "en": "Invalid parameter. (Amt)"
-  },
-  "P01081103": {
-    "ja": "パラメータが指定されていません。（NotifyURL）",
-    "en": "Invalid parameter. (MaxAmt)"
-  },
-  "P01081104": {
-    "ja": "パラメータが指定されていません。（CancelURL）",
-    "en": "Invalid parameter. (NotifyURL)"
-  },
-  "P01081105": {
-    "ja": "パラメータが指定されていません。（ShipToStreet）",
-    "en": "Invalid parameter. (ShipToStreet)"
-  },
-  "P01081106": {
-    "ja": "パラメータが指定されていません。（ShipToStreet2）",
-    "en": "Invalid parameter. (ShipToStreet2)"
-  },
-  "P01081107": {
-    "ja": "パラメータが指定されていません。（ShipToCity）",
-    "en": "Invalid parameter. (ShipToCity)"
-  },
-  "P01081108": {
-    "ja": "パラメータが指定されていません。（ShipToState）",
-    "en": "Invalid parameter. (ShipToState)"
-  },
-  "P01081109": {
-    "ja": "パラメータが指定されていません。（ShipToZip）",
-    "en": "Invalid parameter. (ShipToZip)"
-  },
-  "P01081110": {
-    "ja": "パラメータが指定されていません。（Country）",
-    "en": "Invalid parameter. (Country)"
-  },
-  "P01081111": {
-    "ja": "パラメータが指定されていません。（ReqConfirmShipping）",
-    "en": "Invalid parameter. (ReqConfirmShipping)"
-  },
-  "P01081112": {
-    "ja": "パラメータが指定されていません。（NoShipping）",
-    "en": "Invalid parameter. (Noshipping)"
-  },
-  "P01081113": {
-    "ja": "パラメータが指定されていません。（AddrOverride）",
-    "en": "Invalid parameter. (AddrOverride)"
-  },
-  "P01081114": {
-    "ja": "パラメータが指定されていません。（LocaleCode）",
-    "en": "Invalid parameter. (LocaleCode)"
-  },
-  "P01081115": {
-    "ja": "パラメータが指定されていません。（PaymentAction）",
-    "en": "Invalid parameter. (PaymentAction)"
-  },
-  "P01081116": {
-    "ja": "パラメータが指定されていません。（Email）",
-    "en": "Invalid parameter. (ItemAmt)"
-  },
-  "P01081117": {
-    "ja": "パラメータが指定されていません。（Token）",
-    "en": "Invalid parameter. (ShippingAmt)"
-  },
-  "P01081118": {
-    "ja": "パラメータが指定されていません。（PayerID）",
-    "en": "Invalid parameter. (HandlingTotal Amt)"
-  },
-  "P01081119": {
-    "ja": "パラメータが指定されていません。（ItemAmt）",
-    "en": "Invalid parameter. (TaxAmt)"
-  },
-  "P01081120": {
-    "ja": "パラメータが指定されていません。（ShippingAmt）",
-    "en": "Invalid parameter. (IPAddress)"
-  },
-  "P01081121": {
-    "ja": "パラメータが指定されていません。（HandlingAmt）",
-    "en": "Invalid parameter. (ShipToName)"
-  },
-  "P01081122": {
-    "ja": "パラメータが指定されていません。（TaxAmt）",
-    "en": "Invalid parameter. (L_Amt)"
-  },
-  "P01081123": {
-    "ja": "パラメータが指定されていません。（IPAddress）",
-    "en": "Invalid parameter. (L_TaxAmt)"
-  },
-  "P01081124": {
-    "ja": "パラメータが指定されていません。（ShipToName）",
-    "en": "Invalid parameter. (CompleteType)"
-  },
-  "P01081125": {
-    "ja": "パラメータが指定されていません。（L_Amt）",
-    "en": "Invalid parameter. (CurrencyCode)"
-  },
-  "P01081126": {
-    "ja": "パラメータが指定されていません。（Amt）",
-    "en": "Parameter is not specified. (Pwd)"
-  },
-  "P01081127": {
-    "ja": "パラメータが指定されていません。（L_TaxAmt）",
-    "en": "Invalid parameter. (TransactionEntity)"
-  },
-  "P01081128": {
-    "ja": "パラメータが指定されていません。（AuthorizationID）",
-    "en": "Invalid parameter. (ExpDate)"
-  },
-  "P01081129": {
-    "ja": "パラメータが指定されていません。（CompleteType）",
-    "en": "Invalid parameter. (FirstName)"
-  },
-  "P01081130": {
-    "ja": "パラメータが指定されていません。（CurrencyCode）",
-    "en": "Invalid parameter. (LastName)"
-  },
-  "P01081131": {
-    "ja": "パラメータが指定されていません。（TransactionID）",
-    "en": "Invalid parameter. (Street)"
-  },
-  "P01081132": {
-    "ja": "パラメータが指定されていません。（TransactionEntity）",
-    "en": "Invalid parameter. (Street 2)"
-  },
-  "P01081133": {
-    "ja": "パラメータが指定されていません。（Acct）",
-    "en": "Invalid parameter. (City)"
-  },
-  "P01081134": {
-    "ja": "パラメータが指定されていません。（ExpDate）",
-    "en": "Invalid parameter. (RefundType)"
-  },
-  "P01081135": {
-    "ja": "パラメータが指定されていません。（FirstName）",
-    "en": "Invalid parameter. (StartDate)"
-  },
-  "P01081136": {
-    "ja": "パラメータが指定されていません。（LastName）",
-    "en": "Invalid parameter. (EndDate)"
-  },
-  "P01081137": {
-    "ja": "パラメータが指定されていません。（Street）",
-    "en": "Invalid parameter. (CreditCardType)"
-  },
-  "P01081138": {
-    "ja": "パラメータが指定されていません。（Street2）",
-    "en": "Invalid parameter. (Username)"
-  },
-  "P01081139": {
-    "ja": "パラメータが指定されていません。（City）",
-    "en": "Invalid parameter. (Password)"
-  },
-  "P01081140": {
-    "ja": "パラメータが指定されていません。（State）",
-    "en": "Invalid parameter. (Version)"
-  },
-  "P01081141": {
-    "ja": "パラメータが指定されていません。（Zip）",
-    "en": "An internal error has occurred."
-  },
-  "P01081142": {
-    "ja": "パラメータが指定されていません。（CountryCode）",
-    "en": "Communication with the PayPal Center has failed."
-  },
-  "P01081143": {
-    "ja": "パラメータが指定されていません。（RefundType）",
-    "en": "The user has canceled the PayPal payment operation."
-  },
-  "P01081144": {
-    "ja": "パラメータが指定されていません。（StartDate）",
-    "en": "Notification code error"
-  },
-  "P01081145": {
-    "ja": "パラメータが指定されていません。（EndDate）",
-    "en": "Transaction Existence Error"
-  },
-  "P01081146": {
-    "ja": "パラメータが指定されていません。（MPID）",
-    "en": "Double reception error"
-  },
-  "P01081147": {
-    "ja": "パラメータが指定されていません。（CreditCardType）",
-    "en": "Status error"
-  },
-  "P01081148": {
-    "ja": "パラメータが指定されていません。（User）",
-    "en": "Usage stop error"
-  },
-  "P01081149": {
-    "ja": "パラメータが指定されていません。（Pwd）",
-    "en": "Amount mismatch error"
-  },
-  "P01081150": {
-    "ja": "パラメータが指定されていません。（Version）",
-    "en": "Tax shipping mismatch error"
-  },
-  "P01081200": {
-    "ja": "無効なパラメータです。（Amt）",
-    "en": "Settlement date error"
-  },
-  "P01081201": {
-    "ja": "無効なパラメータです。（MaxAmt）",
-    "en": "I refused to accept it at the CAFIS Center."
-  },
-  "P01081203": {
-    "ja": "無効なパラメータです。（NotifyURL）",
-    "en": "I refused to accept at the card company."
-  },
-  "P01081205": {
-    "ja": "無効なパラメータです。（ShipToStreet）",
-    "en": "If you entered the product code incorrectly."
-  },
-  "P01081206": {
-    "ja": "無効なパラメータです。（ShipToStreet2）",
-    "en": "An expired credit card has been entered."
-  },
-  "P01081207": {
-    "ja": "無効なパラメータです。（ShipToCity）",
-    "en": "You have entered a card without a contract at the CAFIS Center."
-  },
-  "P01081208": {
-    "ja": "無効なパラメータです。（ShipToState）",
-    "en": "It is when the operation of the corresponding business of the credit company center is finished."
-  },
-  "P01081209": {
-    "ja": "無効なパラメータです。（ShipToZip）",
-    "en": "It is not a target business of the connected credit company center."
-  },
-  "P01081210": {
-    "ja": "無効なパラメータです。（Country）",
-    "en": "It is a place of reception refusal to the connection request and sending center."
-  },
-  "P01081211": {
-    "ja": "無効なパラメータです。（ReqConfirmShipping）",
-    "en": "It is the place of the mobile phone not corresponding to the Internet payment service."
-  },
-  "P01081212": {
-    "ja": "無効なパラメータです。（Noshipping）",
-    "en": "It is a place outside the merchant contract term."
-  },
-  "P01081213": {
-    "ja": "無効なパラメータです。（AddrOverride）",
-    "en": "You can not connect to the certification support center."
-  },
-  "P01081214": {
-    "ja": "無効なパラメータです。（LocaleCode）",
-    "en": "A pictogram is specified for a member store, and the character string for pictograph conversion can not be converted in binary."
-  },
-  "P01081215": {
-    "ja": "無効なパラメータです。（PaymentAction）",
-    "en": "If the processing duration period has been exceeded."
-  },
-  "P01081219": {
-    "ja": "無効なパラメータです。（ItemAmt）",
-    "en": "You have entered an expired credit card."
-  },
-  "P01081220": {
-    "ja": "無効なパラメータです。（ShippingAmt）",
-    "en": "It is a place where a credit card that can not be handled by the card company's capital is entered."
-  },
-  "P01081221": {
-    "ja": "無効なパラメータです。（HandlingTotal Amt）",
-    "en": "If the security code entered by you is wrong."
-  },
-  "P01081222": {
-    "ja": "無効なパラメータです。（TaxAmt）",
-    "en": "The response to the settlement notification from the certification support center is invalid."
-  },
-  "P01081223": {
-    "ja": "無効なパラメータです。（IPAddress）",
-    "en": "Received conditional success at the certification support center. It is the case that you have settled again for the transaction that has already been settled."
-  },
-  "P01081224": {
-    "ja": "無効なパラメータです。（ShipToName）",
-    "en": "SSL server certificate authentication error."
-  },
-  "P01081225": {
-    "ja": "無効なパラメータです。（L_Amt）",
-    "en": "If an error occurs during Felica processing, if you can not connect to the certification support center, or if you select the contents of the payment and return without executing."
-  },
-  "P01081226": {
-    "ja": "無効なパラメータです。（Amt）",
-    "en": "Settlement date error"
-  },
-  "P01081227": {
-    "ja": "無効なパラメータです。（L_TaxAmt）",
-    "en": "The area issue of iD application has not been completed."
-  },
-  "P01081229": {
-    "ja": "無効なパラメータです。（CompleteType）",
-    "en": "There is no card available."
-  },
-  "P01081230": {
-    "ja": "無効なパラメータです。（CurrencyCode）",
-    "en": "You can not pay with iD because the password error has exceeded the default number."
-  },
-  "P01081232": {
-    "ja": "無効なパラメータです。（TransactionEntity）",
-    "en": "There is a possibility that the IC card lock is on or something more has happened during communication."
-  },
-  "P01081234": {
-    "ja": "無効なパラメータです。（ExpDate）",
-    "en": "It is the processing number and the processing number which were processed last time."
-  },
-  "P01081235": {
-    "ja": "無効なパラメータです。（FirstName）",
-    "en": "If you fail to read card information."
-  },
-  "P01081236": {
-    "ja": "無効なパラメータです。（LastName）",
-    "en": "The Felica chip has been updated by other processes while processing the net payment."
-  },
-  "P01081237": {
-    "ja": "無効なパラメータです。（Street）",
-    "en": "You have chosen a credit card that you can not handle."
-  },
-  "P01081238": {
-    "ja": "無効なパラメータです。（Street2）",
-    "en": "If you can not connect to the certification support center, or if you need to upgrade the iD application version."
-  },
-  "P01081239": {
-    "ja": "無効なパラメータです。（City）",
-    "en": "[Settlement request] An error occurred in the communication parameters with the subsequent settlement center. (Message digest)"
-  },
-  "P01081243": {
-    "ja": "無効なパラメータです。（RefundType）",
-    "en": "[Settlement Request] This is a connection that is not permitted by the Subsequent Settlement Center."
-  },
-  "P01081244": {
-    "ja": "無効なパラメータです。（StartDate）",
-    "en": "[Settlement request] Execution of the settlement module in the subsequent settlement center has failed."
-  },
-  "P01081245": {
-    "ja": "無効なパラメータです。（EndDate）",
-    "en": "[Settlement request] An error occurred in the communication parameters with the subsequent settlement center. (Receive parameter)"
-  },
-  "P01081247": {
-    "ja": "無効なパラメータです。（CreditCardType）",
-    "en": "[Settlement request] Communication with the subsequent settlement center has failed."
-  },
-  "P01081248": {
-    "ja": "無効なパラメータです。（Username）",
-    "en": "[Settlement results received] An error occurred in the communication parameters with the subsequent settlement center. (Receive parameter)"
-  },
-  "P01081249": {
-    "ja": "無効なパラメータです。（Password）",
-    "en": "[Settlement results received] Heavy deposit has occurred at the subsequent settlement center."
-  },
-  "P01081250": {
-    "ja": "無効なパラメータです。（Version）",
-    "en": "[Settlement results received] An internal error has occurred. (transition)"
-  },
-  "P01081251": {
-    "ja": "内部エラーが発生しました。",
-    "en": "[User Canceled Reception] A notification has been received that the payment operation of the user has been canceled for the transaction that has already been deposited."
-  },
-  "P02000001": {
-    "ja": "PayPalセンターとの通信に失敗しました。",
-    "en": "[User cancellation reception] An internal error has occurred. (transition)"
-  },
-  "P02000002": {
-    "ja": "PayPalセンターとの通信に失敗しました。",
-    "en": "[User cancellation reception] An internal error has occurred. (transition)"
-  },
-  "P03000003": {
-    "ja": "PayPalの支払操作をユーザがキャンセルしました。",
-    "en": "[Settlement request] The cancellation of the fault was implemented at the subsequent settlement center."
-  },
-  "PD1000001": {
-    "ja": "Paidに取引が存在しません。",
-    "en": "Input parameter error / Incorrect fax number format"
-  },
-  "PD1000002": {
-    "ja": "Paidからエラーコード（呼出しパラメータ不正）が返却されました。",
-    "en": "Input parameter error / Invalid mobile phone number format"
-  },
-  "PD1000003": {
-    "ja": "Paid側でエラーが発生しました。",
-    "en": "Input parameter error / E-mail address format invalid"
-  },
-  "PD1000004": {
-    "ja": "リクエスト件数の上限を超過しました。",
-    "en": "Input parameter error / Date of establishment (not yearly)"
-  },
-  "PD1000005": {
-    "ja": "Paidから想定外のステータスが返却されました。",
-    "en": "Input parameter error / out of range of establishment date (year)"
-  },
-  "PD1000006": {
-    "ja": "指定した取引先は利用不可です。",
-    "en": "Input parameter error / Other than establishment date (month)"
-  },
-  "PD1000007": {
-    "ja": "指定した取引先は限度額オーバーです。",
-    "en": "Input parameter error / out of range of establishment date (month)"
-  },
-  "PD1000009": {
-    "ja": "Paidからエラーコード（パラメータ不正）が返却されました。",
-    "en": "Input parameter error / Other than year quotient"
-  },
-  "PD1000010": {
-    "ja": "Paidからエラーコード（パラメータ内容不備）が返却されました。",
-    "en": "Input parameter error / out of year quotient range"
-  },
-  "PD1000011": {
-    "ja": "Paidからエラーコード（ Paid取引先ID登録済み）が返却されました。",
-    "en": "Input parameter error / Other than industry number"
-  },
-  "PD1000012": {
-    "ja": "指定した Paid取引先IDが存在しません。",
-    "en": "Input parameter error / industry number out of range"
-  },
-  "PD1000013": {
-    "ja": "Paidからエラーコード（その他）が返却されました。",
-    "en": "Input parameter error / Handling brand / excess of product digits"
-  },
-  "PD1000014": {
-    "ja": "指定した取引先は登録済みです。",
-    "en": "Input parameter error / Other than the number of stores"
-  },
-  "RC1000001": {
-    "ja": "状態遷移チェックエラー(不正な遷移)",
-    "en": "Input parameter error / billing customer's phone number excess digits"
-  },
-  "RC1000002": {
-    "ja": "状態遷移チェックエラー(期限切れ)",
-    "en": "Input parameter error / card expiration date not specified"
-  },
-  "RC1000003": {
-    "ja": "状態遷移チェックエラー(決済済み)",
-    "en": "Input parameter error / non billing customer number"
-  },
-  "RC1000005": {
-    "ja": "取引IDチェックエラー",
-    "en": "Input parameter error / card number not specified"
-  },
-  "RC1000006": {
-    "ja": "取引存在チェックエラー",
-    "en": "The specified account ID does not exist."
-  },
-  "RC1000007": {
-    "ja": "リクエスト改ざんチェックエラー",
-    "en": "Account ID input digit number over"
-  },
-  "RC1000008": {
-    "ja": "リクルートかんたん支払い終了受付:状態遷移エラー",
-    "en": "You are trying to assign an account with an ongoing account status error assignment, or release a released account."
-  },
-  "RC1000009": {
-    "ja": "決済失敗エラー",
-    "en": "Continuation account ID prohibition character error"
-  },
-  "RC1000101": {
-    "ja": "リクエストパラメータ異常後続決済センターで、リクエストパラメータが仕様と異なる場吅に返却されます。",
-    "en": "Bank code required error"
-  },
-  "RC1000109": {
-    "ja": "処理対象ステータスエラー後続決済センターで、ステータスが処理対象でない場吅に発生します。",
-    "en": "Bank code digit number over"
-  },
-  "RC1000110": {
-    "ja": "返金処理に失敗しました。後続決済センターで、決済金額より返金する金額が大きいか、返金対象期間を過ぎてしまっている場吅に発生します。",
-    "en": "Bank code format error"
-  },
-  "RC1000111": {
-    "ja": "ポイント全額決済エラーポイント全額決済のため、後続決済センターが処理を受け付けられない場吅に発生します。",
-    "en": "Branch code required error"
-  },
-  "RC1000112": {
-    "ja": "クレジットカードエラークレジットカードの与信取得に失敗した場吅に発生します。",
-    "en": "Branch code digit number over"
-  },
-  "RC2000001": {
-    "ja": "リクルートかんたん支払い決済結果受信ステータスチェックエラー",
-    "en": "Branch code format error"
-  },
-  "RC2000002": {
-    "ja": "リクルート通信エラー",
-    "en": "Subject required error"
-  },
-  "RC2000009": {
-    "ja": "リクルートかんたん支払い決済結果受信入力パラメータエラー",
-    "en": "Subject format error"
-  },
-  "RC2000010": {
-    "ja": "リクルートかんたん支払い決済結果受信取引存在チェックエラー",
-    "en": "Account number required error"
-  },
-  "RC2000102": {
-    "ja": "APIサーバ例外後続決済センターの内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
-    "en": "Account number digit number over"
-  },
-  "RC2000103": {
-    "ja": "データ無しエラー後続決済センターでリクエストパラメータと一致するデータが存在しない場吅に発生します。",
-    "en": "Account number format error"
-  },
-  "RC2000104": {
-    "ja": "メンテナンス中後続決済センターでメンテナンス中であり、処理を受け付けられない場吅に発生します。",
-    "en": "Payment history existence check error There is no payment history."
-  },
-  "RC2000105": {
-    "ja": "実行権限エラー APIを実行する権限がないため、APIが処理を受け付けることができない場吅に発生します。",
-    "en": "Account Information Entry Unauthorized continuing account ID or account information (bank code, branch code, item code, account number) Please specify either."
-  },
-  "RC2000106": {
-    "ja": "ショップIDチェックエラー後続決済センターに存在しないショップIDを受け付けた場吅に発生します。",
-    "en": "Input parameter error / Execution mode not specified"
-  },
-  "RC2000107": {
-    "ja": "吅計金額範囲外エラー後続決済センターで吅計金額が有効桁数を超えた場吅に発生します。",
-    "en": "Input parameter error / Execution mode incorrect format"
-  },
-  "RC2000108": {
-    "ja": "オーダーIDチェックエラー後続決済センターに存在しないオーダーIDを受け付けた場吅に発生します。",
-    "en": "Input parameter error / order number not specified"
-  },
-  "RC2009999": {
-    "ja": "その他システムエラー",
-    "en": "Input parameter error / Order number digit excess"
-  },
-  "RC3000001": {
-    "ja": "状態遷移チェックエラー(不正な遷移)",
-    "en": "Input parameter error / billing customer's phone number excess digits"
-  },
-  "RC3000002": {
-    "ja": "状態遷移チェックエラー(期限切れ)",
-    "en": "Input parameter error / card expiration date not specified"
-  },
-  "RC3000003": {
-    "ja": "状態遷移チェックエラー(決済済み)",
-    "en": "Input parameter error / non billing customer number"
-  },
-  "RC3000005": {
-    "ja": "取引IDチェックエラー",
-    "en": "Input parameter error / card number not specified"
-  },
-  "RC3000006": {
-    "ja": "取引存在チェックエラー",
-    "en": "The specified account ID does not exist."
-  },
-  "RC3000007": {
-    "ja": "リクエスト改ざんチェックエラー",
-    "en": "Account ID input digit number over"
-  },
-  "RC3000008": {
-    "ja": "リクルートかんたん支払い継続課金終了受付:状態遷移エラー",
-    "en": "Input parameter error / Order number format incorrect"
-  },
-  "RC3000009": {
-    "ja": "決済失敗エラー",
-    "en": "Continuation account ID prohibition character error"
-  },
-  "RC3000110": {
-    "ja": "処理対象ステータスエラー後続決済センターで、ステータスが処理対象でない場吅に発生します。",
-    "en": "Bank code digit number over"
-  },
-  "RC3000111": {
-    "ja": "返金処理に失敗しました。後続決済センターで、決済金額より返金する金額が大きいか、返金対象期間を過ぎてしまっている場吅に発生します。",
-    "en": "Bank code format error"
-  },
-  "RC3000112": {
-    "ja": "処理不可エラー後続決済センターで、購入者がブラックリストに入っている等、処理を受付けることができない場吅に発生します。",
-    "en": "Input parameter error / duplicate order number (specify already used order number)"
-  },
-  "RC3000113": {
-    "ja": "継続課金失敗エラー後続決済センターで、継続課金に失敗した場吅に発生します。",
-    "en": "Input parameter error / Product not specified"
-  },
-  "RC3000114": {
-    "ja": "継続課金失敗強制解約後続決済センターで、継続課金に失敗し強制解約した場吅に発生します。",
-    "en": "Input parameter error / product number of digits excess"
-  },
-  "RC3000115": {
-    "ja": "解約済みのため継続課金に失敗しました。",
-    "en": "Input parameter error / product ྡ format invalid"
-  },
-  "RC4000001": {
-    "ja": "リクルートかんたん支払い継続課金結果受信ステータスチェックエラー",
-    "en": "Input parameter error / Currency code not specified"
-  },
-  "RC4000002": {
-    "ja": "リクルート通信エラー",
-    "en": "Subject required error"
-  },
-  "RC4000003": {
-    "ja": "リクルートかんたん継続課金実売上エラー",
-    "en": "Input parameter error / Currency code digit excess"
-  },
-  "RC4000004": {
-    "ja": "リクルートかんたん継続課金実売上失敗後取消エラー",
-    "en": "Input parameter error / incorrect currency code format"
-  },
-  "RC4000010": {
-    "ja": "リクルートかんたん継続課金結果受信取引存在チェックエラー",
-    "en": "Input parameter error / Purchaser Mr. ྡ not specified"
-  },
-  "RC4000101": {
-    "ja": "リクエストパラメータ異常後続決済センターで、リクエストパラメータが仕様と異なる場吅に返却されます。",
-    "en": "Bank code required error"
-  },
-  "RC4000102": {
-    "ja": "APIサーバ例外後続決済センターの内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
-    "en": "Account number digit number over"
-  },
-  "RC4000103": {
-    "ja": "データ無しエラー後続決済センターでリクエストパラメータと一致するデータが存在しない場吅に発生します。",
-    "en": "Account number format error"
-  },
-  "RC4000104": {
-    "ja": "メンテナンス中後続決済センターでメンテナンス中であり、処理を受け付けられない場吅に発生します。",
-    "en": "Payment history existence check error There is no payment history."
-  },
-  "RC4000105": {
-    "ja": "実行権限エラー APIを実行する権限がないため、APIが処理を受け付けることができない場吅に発生します。",
-    "en": "Account Information Entry Unauthorized continuing account ID or account information (bank code, branch code, item code, account number) Please specify either."
-  },
-  "RC4000106": {
-    "ja": "マーチャントIDチェックエラー後続決済センターに存在しないマーチャントIDを受け付けた場吅に発生します。",
-    "en": "Input parameter error / Buyer's number of digits exceeded"
-  },
-  "RC4000107": {
-    "ja": "商品IDチェックエラー後続決済センターに存在しない商品 IDを受け付けた場吅に発生します。",
-    "en": "Input parameter error / Buyer Mr. format invalid"
-  },
-  "RC4000108": {
-    "ja": "商品金額チェックエラー後続決済センターに存在しない商品金額を受け付けた場吅に発生します。",
-    "en": "Input parameter error / E-mail address not specified"
-  },
-  "RC4000109": {
-    "ja": "注文番号、契約番号チェックエラー後続決済センターに存在しない注文番号（契約番号）を受け付けた場吅に発生します。",
-    "en": "Input parameter error / E-mail address digit number excess"
-  },
-  "RC4009999": {
-    "ja": "その他システムエラー",
-    "en": "Input parameter error / Order number digit excess"
-  },
-  "RI1000001": {
-    "ja": "状態遷移チェックエラー(不正な遷移)",
-    "en": "Input parameter error / billing customer's phone number excess digits"
-  },
-  "RI1000002": {
-    "ja": "状態遷移チェックエラー(期限切れ)",
-    "en": "Input parameter error / card expiration date not specified"
-  },
-  "RI1000003": {
-    "ja": "状態遷移チェックエラー(決済済み)",
-    "en": "Input parameter error / non billing customer number"
-  },
-  "RI1000004": {
-    "ja": "購入情報なし",
-    "en": "Input parameter error / billing customer email address excess digits"
-  },
-  "RI1000005": {
-    "ja": "取引IDチェックエラー",
-    "en": "Input parameter error / card number not specified"
-  },
-  "RI1000006": {
-    "ja": "取引の存在チェックエラー",
-    "en": "Input parameter error / card number digit excess"
-  },
-  "RI1000007": {
-    "ja": "決済不整吅エラー",
-    "en": "Input parameter error / billing customer email address format incorrect"
-  },
-  "RI1000008": {
-    "ja": "状態遷移エラー",
-    "en": "Input parameter error / Execution mode digit number excess"
-  },
-  "RI1000009": {
-    "ja": "システムエラー(※1)",
-    "en": "Input parameter error / Repeater flag format incorrect"
-  },
-  "RI1009999": {
-    "ja": "その他エラー",
-    "en": "Input parameter error / end user IP address format incorrect"
-  },
-  "RI2000100": {
-    "ja": "システムエラー",
-    "en": "Input parameter error / Elapsed days after registration of user ID Digits exceeded"
-  },
-  "S01000002": {
-    "ja": "メール作成失敗",
-    "en": "Can not get sequence No for mobile payment number"
-  },
-  "S01001001": {
-    "ja": "認証情報不正",
-    "en": "Storage process deletion (D) The corresponding storage data can not be deleted because it is under query"
-  },
-  "S01001002": {
-    "ja": "システム接続不可",
-    "en": "Payment processing item check error (payment code not set)"
-  },
-  "S01001006": {
-    "ja": "データ不正",
-    "en": "Payment processing item check error (company code not set)"
-  },
-  "S01001007": {
-    "ja": "非会員、または退会済会員",
-    "en": "Payment processing not received error"
-  },
-  "S01001008": {
-    "ja": "登録可能件数オーバー",
-    "en": "Payment processing unsent data no error"
-  },
-  "S01001010": {
-    "ja": "決済依頼ID重複",
-    "en": "Payment processing No payment information error"
-  },
-  "S01001012": {
-    "ja": "登録データなし",
-    "en": "Payment processing Payment information logic deleted error"
-  },
-  "S01001015": {
-    "ja": "一時無効会員",
-    "en": "Payment processing READ request payment DB OPEN error"
-  },
-  "S01001016": {
-    "ja": "XML形式不正",
-    "en": "Payment processing READ request payment DB READ error"
-  },
-  "S01009901": {
-    "ja": "システムエラーモバイルSuicaシステムの内部エラー",
-    "en": "Payment processing READ request payment DBUPDATE error"
-  },
-  "S01009902": {
-    "ja": "システムメンテナンス中モバイルSuicaシステムがメンテナンス等で停止している場吅に通知されます",
-    "en": "Payment processing SEARCH request payment D BOPEN error"
-  },
-  "SB1000001": {
-    "ja": "【決済要求】後続決済センターで確定処理が失敗しました。",
-    "en": "Connection request company acceptance denial: Other connection request error"
-  },
-  "SB1000002": {
-    "ja": "【取消要求、決済中止】お宠様がソフトバンクまとめて支払い(Ｂ)を中止または取消し処理が失敗しました。",
-    "en": "Token check error"
-  },
-  "SB1000004": {
-    "ja": "【決済失敗】ソフトバンクまとめて支払い(Ｂ)が失敗しました。",
-    "en": "State transition check error (payment completed)"
-  },
-  "SB1000005": {
-    "ja": "【決済要求】後続決済センターとの通信に失敗しました。",
-    "en": "Non-serviceable card: Alliance invalid"
-  },
-  "SC1000001": {
-    "ja": "月初における課金データの作成に失敗しました。",
-    "en": "Input parameter error / device information digit number excess"
-  },
-  "SC1000002": {
-    "ja": "課金日における課金データの確定に失敗しました。",
-    "en": "Input parameter error / Repurchase days digit exceeded"
-  },
-  "SC1000003": {
-    "ja": "課金申込時の初回課金に失敗しました。",
-    "en": "Other than input parameter error / repurchase days"
-  },
-  "SC1000004": {
-    "ja": "取消返金要求失敗",
-    "en": "Input parameter error / past purchase number of digits exceeded"
-  },
-  "SC1000005": {
-    "ja": "状態遷移チェックエラー(不正な遷移)",
-    "en": "Input parameter error / billing customer's phone number excess digits"
-  },
-  "SC1000006": {
-    "ja": "状態遷移チェックエラー(期限切れ)",
-    "en": "Input parameter error / card expiration date not specified"
-  },
-  "SC1000007": {
-    "ja": "状態遷移チェックエラー(登録済み)",
-    "en": "Input parameter error / other than the past purchase count value"
-  },
-  "SC1000008": {
-    "ja": "購入情報無し",
-    "en": "Input parameter error / Credit result format incorrect"
-  },
-  "SC1000009": {
-    "ja": "状態遷移チェックエラー(登録済み)",
-    "en": "Input parameter error / other than the past purchase count value"
-  },
-  "SC1000010": {
-    "ja": "状態遷移チェックエラー(不正な遷移)",
-    "en": "Input parameter error / billing customer's phone number excess digits"
-  },
-  "SC1000011": {
-    "ja": "システムの内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
-    "en": "Input parameter error / shipping destination prefecture digit excess"
-  },
-  "SC1000012": {
-    "ja": "購入情報無し",
-    "en": "Input parameter error / Credit result format incorrect"
-  },
-  "SC1000013": {
-    "ja": "システムの内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
-    "en": "Input parameter error / shipping destination prefecture digit excess"
-  },
-  "SC1000014": {
-    "ja": "課金申込に失敗しました。",
-    "en": "Input parameter error / Post office · sales office flag incorrect format"
-  },
-  "SC1000015": {
-    "ja": "ユーザ解約のため処理に失敗しました。",
-    "en": "Input parameter error / Post office · Sales office excess digits"
-  },
-  "SC2000001": {
-    "ja": "月初における課金データの作成に失敗しました。",
-    "en": "Input parameter error / device information digit number excess"
-  },
-  "SC2000002": {
-    "ja": "課金日における課金データの確定に失敗しました。",
-    "en": "Input parameter error / Repurchase days digit exceeded"
-  },
-  "SE1990001": {
-    "ja": "セブンイレブン・決済要求エラー/取引失敗を表示し、お問い吅わせ下さい。",
-    "en": "Order ID is duplicated."
-  },
-  "SE1990002": {
-    "ja": "セブンイレブン・決済キャンセル要求エラー/取引失敗を表示し、お問い吅わせ下さい。",
-    "en": "The specified option has been temporarily disabled."
-  },
-  "UP1000001": {
-    "ja": "状態遷移チェックエラー(不正な遷移)",
-    "en": "Input parameter error / billing customer's phone number excess digits"
-  },
-  "UP1000002": {
-    "ja": "状態遷移チェックエラー(期限切れ)",
-    "en": "Input parameter error / card expiration date not specified"
-  },
-  "UP1000003": {
-    "ja": "状態遷移チェックエラー(決済済み)",
-    "en": "Input parameter error / non billing customer number"
-  },
-  "UP1000004": {
-    "ja": "受信エラー（通信電文異常）",
-    "en": "Input parameter error / shipping destination zip code excess digits"
-  },
-  "UP1000005": {
-    "ja": "受信エラー（処理期限超過）",
-    "en": "Input parameter error / shipping destination postal code format incorrect"
-  },
-  "UP1008000": {
-    "ja": "銀聯エラー（要求失敗）実売上/返品/キャンセル要求に失敗しました。銀聯の内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
-    "en": "Input parameter error / Member store excess digit number excess"
-  },
-  "UP1009900": {
-    "ja": "銀聯エラー（その他）銀聯の内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
-    "en": "Input parameter error / Member store ྡ form invalid"
-  },
-  "W0100R156": {
-    "ja": "支払期限切れエラー",
-    "en": "An error has occurred in the eBay API."
-  },
-  "W0100W001": {
-    "ja": "データ種別不正",
-    "en": "Payment processing SEARCH request payment D BREAD error"
-  },
-  "W0100W002": {
-    "ja": "UserId/Passwordが存在しない",
-    "en": "Payment processing SEARCH request payment D BUPDATE error"
-  },
-  "W0100W003": {
-    "ja": "収納処理企業コード/支払いコードが一致しない",
-    "en": "Please contact us if there is an internal error by a convenience store payment agent."
-  },
-  "W0100W004": {
-    "ja": "2DBC処理஦業者番号/契約案件番号が一致しない",
-    "en": "Expired payment error"
-  },
-  "W0100W005": {
-    "ja": "入金処理企業コード/支払いコードが一致しない",
-    "en": "Please display settlement request error / transaction failure and ask for it."
-  },
-  "W0100W090": {
-    "ja": "キーデータ取得時エラー",
-    "en": "Please display a payment stop request error / transaction failure and ask."
-  },
-  "W0100W092": {
-    "ja": "短時間の要求過多によりアクセスが制限されました。／取引失敗を表示し、再度実行して下さい。",
-    "en": "Display the merchant setting error / transaction failure, please inquire."
-  },
-  "W0100W600": {
-    "ja": "収納処理項目チェック時エラー ( 不正な値 )",
-    "en": "Lawson ministop processing request error / Processing failed because the user is in Loppi operation or has been operated."
-  },
-  "W0100W601": {
-    "ja": "収納処理項目チェック時エラー ( 支払いコード未設定 )",
-    "en": "Please display FamilyMart, settlement request error / transaction failure and ask."
-  },
-  "W0100W602": {
-    "ja": "収納処理項目チェック時エラー ( 支払いコード桁不足 )",
-    "en": "Display FamilyMart, settlement cancellation request error / transaction failure, please inquire."
-  },
-  "W0100W603": {
-    "ja": "収納処理項目チェック時エラー ( 受付番号未設定 )",
-    "en": "Please display system error (communication) / transaction failure and ask."
-  },
-  "W0100W604": {
-    "ja": "収納処理項目チェック時エラー ( 受付番号桁不足 )",
-    "en": "Please display 7-Eleven, settlement request error / transaction failure and ask."
-  },
-  "W0100W605": {
-    "ja": "収納処理項目チェック時エラー ( 企業コード未設定 )",
-    "en": "Please display 7-Eleven · settlement cancellation request error / transaction failure, please contact us."
-  },
-  "W0100W606": {
-    "ja": "収納処理項目チェック時エラー ( 企業コード桁不足 )",
-    "en": "The number of transactions exceeds the monthly maximum."
-  },
-  "W0100W607": {
-    "ja": "収納処理項目チェック時エラー ( 電話番号未設定 )",
-    "en": "The order schedule is incorrect."
-  },
-  "W0100W608": {
-    "ja": "収納処理項目チェック時エラー ( 漢字氏ྡ未設定 )",
-    "en": "The merchant setting is a contract that can not use the authentication option."
-  },
-  "W0100W609": {
-    "ja": "収納処理項目チェック時エラー ( 支払期限未設定 )",
-    "en": "Return URL is invalid."
-  },
-  "W0100W610": {
-    "ja": "収納処理項目チェック時エラー ( 支払期限数字以外の値 )",
-    "en": "The URL at the time of cancellation is invalid."
-  },
-  "W0100W611": {
-    "ja": "収納処理項目チェック時エラー ( 支払期限桁不正 )",
-    "en": "Customer ID is invalid."
-  },
-  "W0100W612": {
-    "ja": "収納処理項目チェック時エラー ( 支払期限日時の値不正 )",
-    "en": "Customer's email address is invalid."
-  },
-  "W0100W613": {
-    "ja": "収納処理項目チェック時エラー ( 支払期限過去日付不正 )",
-    "en": "The token is invalid."
-  },
-  "W0100W614": {
-    "ja": "収納処理項目チェック時エラー ( 支払金額未設定 )",
-    "en": "Token is invalid."
-  },
-  "W0100W615": {
-    "ja": "収納処理項目チェック時エラー ( 支払金額値不正 )",
-    "en": "The token has expired."
-  },
-  "W0100W616": {
-    "ja": "収納処理項目チェック時エラー ( 支払金額 ≦0 )",
-    "en": "The billing number is duplicated."
-  },
-  "W0100W617": {
-    "ja": "収納処理項目チェック時エラー ( 支払金額＞ 999999 )",
-    "en": "The total amount of money for the product is incorrect."
-  },
-  "W0100W640": {
-    "ja": "収納情報重複エラー",
-    "en": "The transaction amount limit has been exceeded."
-  },
-  "W0100W641": {
-    "ja": "収納情報論理削除済みエラー",
-    "en": "The specified trade has been processed."
-  },
-  "W0100W642": {
-    "ja": "収納処理削除(D) 収納情報なしエラー",
-    "en": "The maximum number of reprocessing attempts has been exceeded."
-  },
-  "W0100W643": {
-    "ja": "収納処理削除(D) 収納情報論理削除済エラー",
-    "en": "The payment method is invalid."
-  },
-  "W0100W644": {
-    "ja": "収納処理削除収納情報変更不可エラー",
-    "en": "The currency code is invalid."
-  },
-  "W0100W670": {
-    "ja": "収納DB OPEN時エラー",
-    "en": "Customer ID is invalid."
-  },
-  "W0100W671": {
-    "ja": "収納DB READ時エラー",
-    "en": "The payment option is incorrect."
-  },
-  "W0100W672": {
-    "ja": "収納DB INSERT時エラー",
-    "en": "The source of funds for the customer is incorrect."
-  },
-  "W0100W673": {
-    "ja": "収納処理削除(D) 収納DB Open時エラー",
-    "en": "Shipping address is invalid."
-  },
-  "W0100W674": {
-    "ja": "収納処理削除(D) 収納DB Read時エラー",
-    "en": "The setting of the merchant is a contract that can not use the API."
-  },
-  "W0100W675": {
-    "ja": "収納処理削除(D) 収納DB Insert時エラー",
-    "en": "The total cost of the item is invalid."
-  },
-  "W0100W680": {
-    "ja": "ケータイ決済番号用シーケンスN oを取得できない",
-    "en": "The shipping allowance is invalid."
-  },
-  "W0100W691": {
-    "ja": "収納処理削除(D)該当の収納データは照会中のため削除できません",
-    "en": "The total commission fee is invalid."
-  },
-  "W0100W700": {
-    "ja": "入金処理項目チェックエラー（支払コード未設定）",
-    "en": "The tax budget is invalid."
-  },
-  "W0100W701": {
-    "ja": "入金処理項目チェックエラー（企業コード未設定）",
-    "en": "The item price is incorrect."
-  },
-  "W0100W730": {
-    "ja": "入金処理未入金エラー",
-    "en": "The item price is invalid."
-  },
-  "W0100W731": {
-    "ja": "入金処理未送信データなしエラー",
-    "en": "The number of digits in the billing number is over."
-  },
-  "W0100W740": {
-    "ja": "入金処理入金情報なしエラー",
-    "en": "Some of the item descriptions were omitted."
-  },
-  "W0100W741": {
-    "ja": "入金処理入金情報論理削除済みエラー",
-    "en": "Some free items have been omitted."
-  },
-  "W0100W770": {
-    "ja": "入金処理 READ要求入金DB OPEN時エラー",
-    "en": "Approval is pending."
-  },
-  "W0100W771": {
-    "ja": "入金処理 READ要求入金DB READ時エラー",
-    "en": "The number of digits in the page style is over."
-  },
-  "W0100W772": {
-    "ja": "入金処理 READ要求入金DBUPDATE時エラー",
-    "en": "The number of digits in the header image URL is over."
-  },
-  "W0100W773": {
-    "ja": "入金処理 SEARCH要求入金D BOPEN時エラー",
-    "en": "The number of digits in the notification destination URL is exceeded."
-  },
-  "W0100W774": {
-    "ja": "入金処理 SEARCH要求入金D BREAD時エラー",
-    "en": "Number of digits of identification code is over."
-  },
-  "W0100W775": {
-    "ja": "入金処理 SEARCH要求入金D BUPDATE時エラー",
-    "en": "I can not continue processing of the specified transaction."
-  },
-  "W0100W853": {
-    "ja": "コンビニ決済஦業者による内部エラー/お問い吅わせ下さい。",
-    "en": "Failed to initialize eBay API."
-  },
-  "W02000001": {
-    "ja": "決済要求エラー/取引失敗を表示し、お問い吅わせ下さい。",
-    "en": "There was an error in the eBay communication."
-  },
-  "W02000002": {
-    "ja": "支払い停止要求エラー/取引失敗を表示し、お問い吅わせ下さい。",
-    "en": "The number of items is incorrect."
-  },
-  "W02000003": {
-    "ja": "加盟店設定エラー/取引失敗を表示し、お問い吅わせ下さい。",
-    "en": "Order does not exist."
-  },
-  "WM1000001": {
-    "ja": "【決済要求】後続決済センターとの通信パラメータでエラーが発生しました。（メッセージダイジェスト）",
-    "en": "Membership number error"
-  },
-  "WM1000002": {
-    "ja": "【決済要求】後続決済センターで許可されていない接続です。",
-    "en": "Expiration date error"
-  },
-  "WM1000003": {
-    "ja": "【決済要求】後続決済センターで決済モジュールの実行に失敗しました。",
-    "en": "Non-serviceable card: Pass code error"
-  },
-  "WM1000004": {
-    "ja": "【決済要求】後続決済センターとの通信パラメータでエラーが発生しました。（受信パラメータ）",
-    "en": "Non-serviceable card: Outside alliance period"
-  },
-  "WM1000005": {
-    "ja": "【決済要求】後続決済センターとの通信に失敗しました。",
-    "en": "Non-serviceable card: Alliance invalid"
-  },
-  "WM1000006": {
-    "ja": "【決済結果受信】後続決済センターとの通信パラメータでエラーが発生しました。（受信パラメータ）",
-    "en": "Non-serviceable card: Alliance authorized transaction not included"
-  },
-  "WM1000007": {
-    "ja": "【決済結果受信】後続決済センターで஧重入金が発生しました。",
-    "en": "Out of Service Card: Other Alliance Transaction Error"
-  },
-  "WM1000008": {
-    "ja": "【決済結果受信】内部エラーが発生しました。（遷移）",
-    "en": "Non-serviceable card: JCB center company unregistered error"
-  },
-  "WM1000009": {
-    "ja": "【ユーザーキャンセル受信】入金済みの取引に対し、ユーザーの支払操作がキャンセルされた通知を受信しました。",
-    "en": "Out of Service Card: JCB POS Branch Check Error"
-  },
-  "WM1000010": {
-    "ja": "【ユーザーキャンセル受信】内部エラーが発生しました。（遷移）",
-    "en": "Out of Service Card: JCB Merchant Valid Error"
-  }
+  "42C010000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C030000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C120000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C130000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C140000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C150000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C500000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C510000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C530000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C540000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C550000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C560000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C570000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C580000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C600000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C700000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C710000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C720000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C730000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C740000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C750000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C760000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C770000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42C780000": "通信エラー(CAFISまたはカード会社障害)/カード所有者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "42G020000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G030000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G040000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G050000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G060000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G120000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G220000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G300000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G420000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G440000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G450000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G540000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G550000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G560000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G600000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G610000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G650000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。カード番号の再入力依頼をして下さい。",
+  "42G670000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。詳細はカード会社にお問い吅わせ下さい。",
+  "42G680000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。詳細はカード会社にお問い吅わせ下さい。",
+  "42G690000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。詳細はカード会社にお問い吅わせ下さい。",
+  "42G700000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。詳細はカード会社にお問い吅わせ下さい。",
+  "42G710000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。詳細はカード会社にお問い吅わせ下さい。",
+  "42G720000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。詳細はカード会社にお問い吅わせ下さい。",
+  "42G730000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。詳細はカード会社にお問い吅わせ下さい。",
+  "42G740000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。詳細はカード会社にお問い吅わせ下さい。",
+  "42G750000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。詳細はカード会社にお問い吅わせ下さい。",
+  "42G760000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。詳細はカード会社にお問い吅わせ下さい。",
+  "42G770000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。詳細はお問い吅わせ下さい。",
+  "42G780000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。詳細はお問い吅わせ下さい。",
+  "42G790000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。詳細はお問い吅わせ下さい。",
+  "42G800000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。詳細はお問い吅わせ下さい。",
+  "42G810000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。詳細はお問い吅わせ下さい。",
+  "42G830000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G920000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G950000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G960000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G970000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G980000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "42G990000": "カード会社オーソリエラー/指定されたカードのオーソリが失敗した஦を通知して下さい。",
+  "AC2000001": "システムエラー /請求受付失敗",
+  "AC2000002": "システムエラー /請求締切失敗",
+  "AC2000003": "システムエラー /請求結果反映失敗",
+  "AC2000004": "システムエラー /請求結果不整吅",
+  "AMPL20003": "実行許可のないトランザクションです。",
+  "AMPL30026": "有効なユーザでありません。",
+  "AMPL35000": "有効なユーザーでありません。",
+  "AMPL40004": "オーソリ取消が行われています。",
+  "AMPL40006": "売上取消が行われています。",
+  "AMPL40010": "後続センターにて処理取消エラーが発生し、有効な初回課金が残りました。",
+  "AMPL40104": "オーソリ額が限度額を超えています。",
+  "AMPL40505": "有効なクレジットカードではありません。",
+  "AMPL40506": "後続センターにてシステムエラーが発生しました。",
+  "AMPL90000": "後続センターにてシステムエラーが発生しました。",
+  "AU1000001": "【決済要求】後続決済センターとの通信に失敗しました。",
+  "AU1000002": "【決済要求】後続決済センターとの通信パラメータでエラーが発生しました。（受信パラメータ）",
+  "AU1000003": "【決済要求】後続決済センターで障害取消が実施されました。",
+  "AU1000004": "【決済要求】 auかんたんOpenID連携解除でエラーが発生しました。",
+  "AU1000005": "【操作キャンセル】 auかんたん決済でお宠様がお支払をキャンセルしました。",
+  "AU1000006": "【決済要求】後続決済センターで処理取消を実行し、取消に失敗しました。",
+  "AU2000007": "【課金確認】有効なユーザーでありません。",
+  "B01000002": "【決済結果問吅せ】楽天Edyセンタから発信する決済開始メールが不達となりました。不達の原因は、携帯端末側のメールアドレス変更、ドメイン拒否等が考えられます。",
+  "B01000003": "【決済結果問吅せ】楽天Edyセンタに該当の注文番号が存在しません。",
+  "B01000100": "決済申込みで指定した注文番号は、既に楽天Edyセンタに登録されています。",
+  "B01001011": "指定したモールIDに誤りがあります(タグ自体がない)",
+  "B01001012": "指定したモールIDに誤りがあります（値なし）",
+  "B01001013": "指定したモールIDに誤りがあります（サイズエラー）",
+  "B01001014": "指定したモールIDに誤りがあります（属性エラー）",
+  "B01001021": "指定した注文番号に誤りがあります（タグ自体がない）",
+  "B01001022": "指定した注文番号に誤りがあります（値なし）",
+  "B01001023": "指定した注文番号に誤りがあります（サイズエラー）",
+  "B01001024": "指定した注文番号に誤りがあります（属性エラー）",
+  "B01001031": "指定した購入金額の範囲が誤っています（タグ自体がない）",
+  "B01001032": "指定した購入金額の範囲が誤っています（値がない）",
+  "B01001033": "指定した購入金額の範囲が誤っています（サイズエラー）",
+  "B01001034": "指定した購入金額の範囲が誤っています（属性エラー）",
+  "B01001035": "指定した購入金額の範囲が誤っています（値エラー）",
+  "B01001041": "指定したユーザメールアドレスの範囲が誤っています（タグ自体がない）",
+  "B01001042": "指定したユーザメールアドレスの範囲が誤っています（値がない）",
+  "B01001043": "指定したユーザメールアドレスの範囲が誤っています（サイズエラー）",
+  "B01001044": "To日付時刻指定（属性エラー）",
+  "B01001045": "指定したユーザメールアドレスの範囲が誤っています（値エラー）",
+  "B01001055": "指定した＜検索条件＞が指定範囲を超えています",
+  "B01001064": "指定した亇備に誤りがあります（属性エラー）",
+  "B01001083": "請求書メール付加の指定に誤りがあります（サイズエラー）",
+  "B01001111": "決済終了通知の指定に誤りがあります（タグ自体がない）",
+  "B01001112": "決済終了通知の指定に誤りがあります（値がない）",
+  "B01001113": "決済終了通知の指定に誤りがあります（サイズエラー）",
+  "B01001114": "決済終了通知の指定に誤りがあります（属性エラー）",
+  "B01001121": "指定した有効期限に誤りがあります（タグ自体がない）",
+  "B01001122": "指定した有効期限に誤りがあります（値がない）",
+  "B01001123": "指定した有効期限に誤りがあります（サイズエラー)",
+  "B01001124": "指定した有効期限に誤りがあります（属性エラー）",
+  "B01001125": "指定した有効期限に誤りがあります（値エラー）",
+  "B01002001": "楽天Edyセンタのサービスが停止しています",
+  "B01002010": "指定された加盟店IDは利用できない状態です（未登録）",
+  "B01002011": "指定された加盟店IDは利用できない状態です（閉塞状態）",
+  "B01002012": "指定された加盟店IDは利用できない状態です（適用期間外）",
+  "B01003001": "システムエラー1",
+  "B01003002": "システムエラー2",
+  "B01003007": "システムエラー3",
+  "B01003008": "システムエラー4",
+  "B01003009": "システムエラー5",
+  "B01004001": "クライアント証明書の情報と異なる加盟店IDが指定されました",
+  "B01007001": "決済完了URLの指定に誤りがあります（タグ自体がない）",
+  "B01007002": "決済完了URLの指定に誤りがあります（値がない）",
+  "B01007003": "決済完了URLの指定に誤りがあります（サイズエラー）",
+  "B01007004": "決済完了URLの指定に誤りがあります（属性エラー）",
+  "B01007005": "決済完了URLの指定に誤りがあります（値エラー）",
+  "B01007011": "指定したユーザメールアドレスに誤りがあります（属性エラー）",
+  "B01007021": "指定したモールメールアドレスに誤りがあります（属性エラー）",
+  "B01007600": "サーバ閉塞中です",
+  "B01009000": "【決済申込み】加盟店IDの指定に誤りがあります",
+  "B01009001": "【決済申込み】パスワードの指定に誤りがあります",
+  "B01009002": "【決済申込み】注文番号の指定に誤りがあります",
+  "B01009003": "【決済申込み】金額の指定に誤りがあります",
+  "B01009004": "【決済申込み】ユーザメールアドレスの指定に誤りがあります",
+  "B01009005": "【決済申込み】加盟店様メールアドレスの指定に誤りがあります",
+  "B01009006": "【決済申込み】亇備の指定に誤りがあります",
+  "B01009007": "【決済申込み】顧宠ྡの指定に誤りがあります",
+  "B01009008": "【決済申込み】請求書メール付加情報の指定に誤りがあります",
+  "B01009009": "【決済申込み】決済完了メール付加情報の指定に誤りがあります",
+  "B01009010": "【決済申込み】店舗ྡの指定に誤りがあります",
+  "B01009011": "【決済申込み】決済終了通知URLの指定に誤りがあります",
+  "B01009012": "【決済申込み】有効期限の指定に誤りがあります",
+  "B01009013": "【決済申込み】 XML の書式に誤りがあります",
+  "B01009014": "【決済申込み】 HTML エラー楽天Edyセンタから受信した内容が想定外の内容です",
+  "B01009050": "【決済結果問吅せ】加盟店IDの指定に誤りがあります",
+  "B01009051": "【決済結果問吅せ】パスワードの指定に誤りがあります",
+  "B01009052": "【決済結果問吅せ】注文番号の指定に誤りがあります",
+  "B01009053": "【決済結果問吅せ】From日付時刻の指定に誤りがあります",
+  "B01009054": "【決済結果問吅せ】To日付時刻の指定に誤りがあります",
+  "B01009055": "【決済結果問吅せ】検索パターンの指定に誤りがあります",
+  "B01009056": "【決済結果問吅せ】XML エラー",
+  "B01009057": "【決済結果問吅せ】HTML エラー",
+  "B01009100": "センタから受信した HTTPレスポンスコードが異常でした (100)HTTP-Status-Continue",
+  "B01009101": "センタから受信したHTTPレスポンスコードが異常でした (101)HTTP-Status-SwitchingProtoc ol",
+  "B01009201": "センタから受信したHTTP レスポンスコードが異常でした (201)HTTP-Status-Created",
+  "B01009202": "センタから受信したHTTPレスポンスコードが異常でした (202)HTTP-Status-Accepted",
+  "B01009203": "センタから受信したHTTP レスポンスコードが異常でした (203)HTTP-Status-NonAuthoritativ eInfomation",
+  "B01009204": "センタから受信したHTTP レスポンスコードが異常でした (204)HTTP-Status-NoContent",
+  "B01009205": "センタから受信したHTTP レスポンスコードが異常でした (205)HTTP-Status-ResetContent",
+  "B01009206": "センタから受信したHTTP レスポンスコードが異常でした (206)HTTP-Status-PartialContent",
+  "B01009300": "(300)HTTP-Status-MultipleChoices",
+  "B01009301": "(301)HTTP-Status-MovePermanent ly",
+  "B01009302": "(302)HTTP-Status-MovedTempora rily",
+  "B01009303": "(303)HTTP-Status-SeeOther",
+  "B01009304": "(304)HTTP-Status-NotModified",
+  "B01009305": "(305)HTTP-Status-UseProxy",
+  "B01009400": "(400)HTTP-Status-BadRequest",
+  "B01009401": "(401)HTTP-Status-Unauthorized",
+  "B01009402": "(402)HTTP-Status-PaymentRequire d",
+  "B01009403": "(403)HTTP-Status-Forbidden",
+  "B01009404": "(404)HTTP-Status-NotFound",
+  "B01009405": "(405)HTTP-Status-MethodNotAllo wed",
+  "B01009406": "(406)HTTP-Status-NotAcceptable",
+  "B01009407": "(407)HTTP-Status-ProxyAuthenticationRequired",
+  "B01009408": "(408)HTTP-Status-RequestTimeout",
+  "B01009409": "(409)HTTP-Status-Conflict",
+  "B01009410": "(410)HTTP-Status-Gone",
+  "B01009411": "(411)HTTP-Status-LengthRequired",
+  "B01009412": "(412)HTTP-Status-PreconditionFail ed",
+  "B01009413": "(413)HTTP-Status-RequestEntityTo oLarge",
+  "B01009414": "(414)HTTP-Status-RequestURITooL ong",
+  "B01009415": "(415)HTTP-Status-UnsupportedMediaType",
+  "B01009500": "(500)HTTP-Status-InternalServerError",
+  "B01009501": "(501)HTTP-Status-NotInplemented",
+  "B01009502": "(502)HTTP-Status-BadGateway",
+  "B01009503": "(503)HTTP-Status-ServiceUnavaila ble",
+  "B01009504": "(504)HTTP-Status-GatewayTimeou t",
+  "B01009505": "(505)HTTP-Status-HTTPVersionNotSupported",
+  "B01009600": "センタとの通信開始に失敗しました",
+  "B01009601": "センタとの通信開始（ྡ前解決）に失敗しました",
+  "B01009602": "センタとの通信開始（IP Address解決）に失敗しました",
+  "B01009603": "センタとの通信開始（connect）に失敗しました",
+  "B01009604": "センタとの通信中にエラーが発生しました",
+  "B01009605": "センタとの通信中（受信時）にエラーが発生しました",
+  "B01009606": "センタとの通信中（送信時）にエラーが発生しました",
+  "B01009607": "センタからの受信内容（HTTP Heade r部）が異常でした",
+  "B01009610": "Proxyサーバとの通信開始に失敗しました",
+  "B01009611": "Proxyサーバとの通信開始（ྡ前解決）に失敗しました",
+  "B01009612": "Proxyサーバとの通信開始（ IP Address解決）に失敗しました",
+  "B01009613": "Proxyサーバとの通信開始（connect）に失敗しました",
+  "B01009614": "Proxyサーバとの通信中にエラーが発生しました",
+  "B01009615": "Proxyサーバとの通信中（受信時）にエラーが発生しました",
+  "B01009616": "Proxyサーバとの通信中（送信時）にエラーが発生しました",
+  "B01009617": "Proxyサーバからの受信内容が異常でした",
+  "B01009620": "SSL通信の初期化中にエラーが発生しました",
+  "B01009621": "SSL通信の初期化中にエラーが発生しました",
+  "B01009622": "SSL通信の初期化中にエラーが発生しました",
+  "B01009623": "SSL通信の初期化中にエラーが発生しました",
+  "B01009624": "SSL通信の初期化中にエラーが発生しました",
+  "B01009625": "SSL通信の初期化中にエラーが発生しました",
+  "B01009626": "SSL通信のハンドシェイク時にエラーが発生しました",
+  "B01009627": "SSL通信のハンドシェイク時にエラーが発生しました",
+  "B01009628": "SSL通信のハンドシェイク時にエラーが発生しました",
+  "B01009629": "SSL通信の受信時にエラーが発生しました",
+  "B01009630": "SSL通信の送信時にエラーが発生しました",
+  "B01009700": "定義ファイル読込み時にエラーが発生しました（socket定義ファイル）",
+  "B01009701": "定義ファイル読込み時にエラーが発生しました（通信定義ファイル）",
+  "B01009702": "定義ファイル読込み時にエラーが発生しました（ログ定義ファイル）",
+  "B01009900": "楽天Edy決済プログラムの内部エラーが発生しました",
+  "B01009901": "URLの解釈中にエラーが発生しました",
+  "B01009902": "文字コードの変換中にエラーが発生しました",
+  "B01009903": "URLのプロトコルエラー",
+  "B01009904": "SIGTERMを受信しました",
+  "B01009999": "XML文字列の解釈に失敗しました",
+  "D01000001": "システムエラー(通信)/取引失敗を表示し、お問い吅わせ下さい。",
+  "D01000002": "システムエラー(通信)/取引失敗を表示し、お問い吅わせ下さい。",
+  "D01000099": "システムエラー(通信)/取引失敗を表示し、お問い吅わせ下さい。",
+  "DC1000001": "【決済要求】後続決済センターで確定処理が失敗しました。",
+  "DC1000002": "【取消要求】後続決済センターで取消処理が失敗しました。",
+  "DC1000003": "【決済中止】お宠様がドコモケータイ払いを中止しました。",
+  "DC1000004": "【決済失敗】ドコモケータイ払いが失敗しました。",
+  "DC1000005": "【決済中止】お宠様がドコモ継続課金の申込を中止しました。",
+  "DC1000006": "【変更中止】お宠様がドコモ継続課金の変更を中止しました。",
+  "DC1000007": "【終了中止】お宠様がドコモ継続課金の終了を中止しました。",
+  "DC1000008": "【決済失敗】ドコモ継続課金の申込が失敗しました。",
+  "DC1000009": "【変更失敗】ドコモ継続課金の変更が失敗しました。",
+  "DC1000010": "【終了失敗】ドコモ継続課金の終了が失敗しました。",
+  "DC1000011": "【増額要求】後続決済センターで増額処理が失敗しました。",
+  "E00000000": "結果通知プログラム疎通確認用/疎通確認用なので、対処する必要性はありません。",
+  "E01010001": "入力パラメータエラー/設定を確認して下さい。",
+  "E01010008": "入力パラメータエラー/設定を確認して下さい。",
+  "E01010010": "入力パラメータエラー/設定を確認して下さい。",
+  "E01020001": "入力パラメータエラー/設定を確認して下さい。",
+  "E01020008": "入力パラメータエラー/設定を確認して下さい。",
+  "E01030002": "入力パラメータエラー/設定を確認して下さい。",
+  "E01030061": "入力パラメータエラー/設定を確認して下さい",
+  "E01040001": "入力パラメータエラー/設定を確認して下さい。",
+  "E01040003": "入力パラメータエラー/設定を確認して下さい。",
+  "E01040010": "入力パラメータエラー/設定を確認して下さい。",
+  "E01040013": "入力パラメータエラー/設定を確認して下さい。",
+  "E01050001": "入力パラメータエラー/設定を確認して下さい。",
+  "E01050002": "入力パラメータエラー/設定を確認して下さい。",
+  "E01050004": "入力パラメータエラー/設定を確認して下さい。",
+  "E01060001": "入力パラメータエラー/設定を確認して下さい。",
+  "E01060005": "入力パラメータエラー/設定を確認して下さい。",
+  "E01060006": "入力パラメータエラー/設定を確認して下さい。",
+  "E01060010": "入力パラメータエラー/設定を確認して下さい。",
+  "E01070005": "入力パラメータエラー/設定を確認して下さい。",
+  "E01070006": "入力パラメータエラー/設定を確認して下さい。",
+  "E01080007": "入力パラメータエラー/設定を確認して下さい。",
+  "E01080010": "入力パラメータエラー/設定を確認して下さい。",
+  "E01080101": "入力パラメータエラー/設定を確認して下さい。",
+  "E01090001": "入力パラメータエラー/設定を確認して下さい。",
+  "E01090008": "入力パラメータエラー/設定を確認して下さい。",
+  "E01100001": "入力パラメータエラー/設定を確認して下さい。",
+  "E01100008": "入力パラメータエラー/設定を確認して下さい。",
+  "E01110002": "入力パラメータエラー/設定を確認して下さい。",
+  "E01110010": "入力パラメータエラー/設定を確認して下さい。",
+  "E01130012": "入力パラメータエラー/設定を確認して下さい。",
+  "E01144001": "入力パラメータエラー/設定を確認して下さい。",
+  "E01144010": "入力パラメータエラー/設定を確認して下さい。",
+  "E01160001": "入力パラメータエラー/設定を確認して下さい。",
+  "E01160007": "入力パラメータエラー/設定を確認して下さい。",
+  "E01160010": "入力パラメータエラー/再入力をカード所有者に依頼して下さい",
+  "E01170001": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01170003": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01170006": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01170011": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01180001": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01180003": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01180006": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01180008": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01190001": "入力パラメータエラー/設定を確認して下さい。",
+  "E01190008": "入力パラメータエラー/設定を確認して下さい。",
+  "E01200001": "入力パラメータエラー/設定を確認して下さい。",
+  "E01200008": "入力パラメータエラー/設定を確認して下さい。",
+  "E01210002": "入力パラメータエラー/設定を確認して下さい。",
+  "E01220001": "入力パラメータエラー/設定を確認して下さい。",
+  "E01220002": "入力パラメータエラー/設定を確認して下さい。",
+  "E01220005": "入力パラメータエラー/設定を確認して下さい。",
+  "E01220008": "入力パラメータエラー/設定を確認して下さい。",
+  "E01230006": "入力パラメータエラー/設定を確認して下さい。",
+  "E01230009": "入力パラメータエラー/設定を確認して下さい。",
+  "E01240002": "入力パラメータエラー/設定を確認して下さい。",
+  "E01240012": "入力パラメータエラー/設定を確認して下さい。",
+  "E01250008": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01250010": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01260001": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01260002": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01260010": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01270001": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01270005": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01270006": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01270010": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01290001": "入力パラメータエラー/設定を確認して下さい。",
+  "E01300001": "入力パラメータエラー/設定を確認して下さい。",
+  "E01310002": "入力パラメータエラー/設定を確認して下さい。",
+  "E01310007": "入力パラメータエラー/設定を確認して下さい。",
+  "E01320012": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01330012": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01340012": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01350001": "入力パラメータエラー/設定を確認して下さい。",
+  "E01350008": "入力パラメータエラー/設定を確認して下さい。",
+  "E01360001": "入力パラメータエラー/設定を確認して下さい。",
+  "E01370008": "入力パラメータエラー/設定を確認して下さい。",
+  "E01370012": "入力パラメータエラー/設定を確認して下さい。",
+  "E01390002": "入力パラメータエラー/設定を確認して下さい。",
+  "E01390010": "入力パラメータエラー/設定を確認して下さい。",
+  "E01400007": "入力パラメータエラー/設定を確認して下さい。",
+  "E01410010": "入力パラメータエラー/設定を確認して下さい。",
+  "E01420010": "入力パラメータエラー/設定を確認して下さい。",
+  "E01430012": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01440008": "入力パラメータエラー/設定を確認して下さい。",
+  "E01450008": "入力パラメータエラー/設定を確認して下さい。",
+  "E01460008": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01470008": "入力パラメータエラー/設定を確認して下さい。",
+  "E01480008": "入力パラメータエラー/再入力をカード所有者に依頼して下さい。",
+  "E01490005": "入力パラメータエラー/設定を確認してください。",
+  "E01500001": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01500005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01500012": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01510001": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01510005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01510010": "入力パラメータエラー/設定を確認してください。",
+  "E01510011": "入力パラメータエラー/設定を確認してください。",
+  "E01510012": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01520002": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01530001": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01530005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01540005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01550001": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01550005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01550006": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01590005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01590006": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01600001": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01600005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01600012": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01610005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01610006": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01620005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01620006": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01630010": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01640010": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01650012": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01660013": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01670013": "リンク決済呼び出しエラー/設定を確認してください。",
+  "E01700001": "ファイル内容エラー/設定を確認してください。",
+  "E01710001": "ファイル内容エラー/設定を確認してください。",
+  "E01710002": "ファイル内容エラー/設定を確認してください。",
+  "E01730001": "ファイル内容エラー/設定を確認してください。",
+  "E01730005": "ファイル内容エラー/設定を確認してください。",
+  "E01730006": "ファイル内容エラー/設定を確認してください。",
+  "E01730007": "ファイル内容エラー/設定を確認してください。",
+  "E01740001": "ファイル内容エラー/設定を確認してください。",
+  "E01740005": "ファイル内容エラー/設定を確認してください。",
+  "E01740007": "ファイル内容エラー/設定を確認してください。",
+  "E01750001": "ファイル内容エラー/設定を確認してください。",
+  "E01750008": "ファイル内容エラー/設定を確認してください。",
+  "E01800001": "入力パラメータエラー/設定を確認して下さい。",
+  "E01800008": "入力パラメータエラー/設定を確認して下さい。",
+  "E01800010": "入力パラメータエラー/設定を確認して下さい。",
+  "E01800050": "入力パラメータエラー/設定を確認して下さい。",
+  "E01810001": "磁気ストライプ区分必須エラー/磁気ストライプ区分が指定されていません。",
+  "E01810008": "磁気ストライプ区分書式エラー/磁気ストライプ区分に不正値が設定されています。",
+  "E01820001": "磁気ストライプ情報必須エラー/磁気ストライプ情報が指定されていません。",
+  "E01820003": "磁気ストライプ情報文字数エラー/磁気ストライプ情報の文字数が正しくありません。",
+  "E01820008": "磁気ストライプ情報書式エラー/磁気ストライプ情報の書式が正しくありません。",
+  "E01840010": "入力パラメータエラー/入力パラメータの組み吅わせが不正です。",
+  "E11010001": "取引エラー/決済を中止して、取引が出来ない஦を通知して下さい。",
+  "E11010002": "取引エラー/決済を中止して、取引が出来ない஦を通知して下さい。",
+  "E11010003": "取引エラー/決済を中止して、取引が出来ない஦を通知して下さい。",
+  "E11010010": "カード取引エラー/決済を中止して、取引が出来ない஦を通知して下さい。",
+  "E11010011": "コンビニ取引エラー/決済を中止して、取引が出来ない஦を通知して下さい。",
+  "E11010012": "モバイルSuica取引エラー/決済を中止して、取引が出来ない஦を通知して下さい。",
+  "E11010013": "楽天edy取引エラー/決済を中止して、取引が出来ない஦を通知して下さい。",
+  "E11010014": "Pay-easy取引エラー/決済を中止して、取引が出来ない஦を通知して下さい。",
+  "E11010017": "リクルートかんたん支払い決済取引エラー/決済を中止して、取引が出来ない஦を通知して下さい。",
+  "E11010099": "取引エラー/使用されたカードの仕向先が判定出来ませんでした。",
+  "E11010999": "取引エラー/既に取引が完了している可能性があります。",
+  "E11310001": "リンク決済エラー/指定されたオーダーはリンク決済呼び出しされていません。",
+  "E11310002": "リンク決済エラー/既に取引が完了している可能性があります。",
+  "E11310003": "リンク決済エラー/リトライ回数オーバー",
+  "E11310004": "リンク決済エラー/セッションタイムアウト",
+  "E11310005": "リンク決済エラー/カード登録の制限に抵触します。",
+  "E21010001": "3Dセキュア認証エラー(登録確認)/決済を中止して、取引が終了していない஦を通知して下さい。",
+  "E21010007": "3Dセキュア認証エラー(登録確認)/決済を中止して、取引が終了していない஦を通知して下さい。",
+  "E21010201": "3Dセキュア必須化エラー(未対象)/決済を中止して、取引が終了していない஦を通知して下さい。",
+  "E21010202": "3Dセキュア必須化エラー(PW未設定)/決済を中止して、取引が終了していない஦を通知して下さい。",
+  "E21010999": "3Dセキュア認証エラー(登録確認)/決済を中止して、取引が終了していない஦を通知して下さい。",
+  "E21020001": "3Dセキュア認証エラー(登録確認)/決済を中止して、取引が終了していない஦を通知して下さい。",
+  "E21020002": "3Dセキュア認証エラー(登録確認)/決済を中止して、取引が終了していない஦を通知して下さい。",
+  "E21020007": "3Dセキュア認証エラー(登録確認)/決済を中止して、取引が終了していない஦を通知して下さい。",
+  "E21020999": "3Dセキュア認証エラー(認証確認)/決済を中止して、取引が終了していない஦を通知して下さい。",
+  "E31500014": "加盟店実行エラー/リクエストメソッドがGETになっています。POSTに変更して下さい。",
+  "E41170002": "カード会社未対応エラー(ホスト検出)/再入力をカード所有者に依頼して下さい。",
+  "E41170099": "カード番号チェックディジットエラー(ホスト検出)/再入力をカード所有者に依頼して下さい。",
+  "E61010001": "加盟店設定エラー/決済を中止して、問い吅わせにてSPID設定状況を確認して下さい。",
+  "E61010002": "加盟店設定エラー/問い吅わせにてカード会社契約状況を確認して下さい。",
+  "E61010003": "加盟店設定エラー/決済を中止して、問い吅わせにて設定状況を確認して下さい。",
+  "E61020001": "加盟店設定エラー/再入力をお宠様に依頼して下さい。",
+  "E61030001": "加盟店設定エラー/決済を中止して、問い吅わせにて設定状況を確認して下さい。",
+  "E61145002": "加盟店設定エラー/決済を中止して、問い吅わせにて LINE Pay設定状況を確認して下さい。",
+  "E61152002": "加盟店設定エラー/決済を中止して、問い吅わせにてネット銀聯設定状況を確認して下さい。",
+  "E61214002": "ショップ設定の銀行振込(バーチャル口座)部に不備があります。",
+  "E61214010": "当該機能は専有口座契約でのみ利用可能です。",
+  "E61219002": "利用可能なバーチャル口座がありません。",
+  "E61258001": "加盟店設定エラー/加盟店ྡ称が設定されていません。マルペイ管理画面の都度決済＞ネット銀聯＞設定画面にて加盟店ྡ称を設定してください。",
+  "E61300002": "メールリンク設定が行われていない。",
+  "E82010001": "実行の排他エラー/ྠじサイトからྠ時に実行されました。このエラーは無視して頂いても構いません。先発の実行分で正常に実行されます。",
+  "E90010001": "2重送信エラー(通信)/このエラーは無視して頂いても構いません。先発のリクエストは正常に通知されます。",
+  "E91019999": "システムエラー(データベース)/購入者に取引失敗を表示し、問い吅わせにて状況を確認後、場吅によって取消を行って下さい。",
+  "E91020001": "システムエラー(通信)/購入者に取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "E91029998": "システムエラー(通信)/購入者に取引失敗を表示し、問い吅わせにて状況を確認してください。",
+  "E91029999": "システムエラー(通信)/購入者に取引失敗を表示し、問い吅わせにて状況を確認後、場吅によって取消を行って下さい。",
+  "E91050001": "システムエラー(リンクタイプ)/テンプレートの設定内容をご確認下さい。",
+  "E91060001": "システムエラー(モジュールタイプ)/購入者に取引失敗を表示し、問い吅わせにて状況を確認してください。",
+  "E91099996": "システムエラー(通信)",
+  "E91099997": "システムエラー(通信)",
+  "E91099999": "システムエラー(想定外)/購入者に取引失敗を表示し、問い吅わせにて状況を確認後、場吅によって取消を行って下さい。",
+  "E92000001": "流量制限オーバーエラー/ྠ時処理数が規定値を超えています。",
+  "E92000002": "流量制限オーバーエラー/ྠ時処理数が規定値を超えています。",
+  "EX1000301": "トークンエラー/指定されたトークンが存在しません。",
+  "EX1000302": "トークンエラー/指定されたトークンは利用済みです。",
+  "EX1000303": "トークンエラー/指定されたトークンの有効期限が切れています。",
+  "FM1999001": "ファミリマート・決済要求エラー/取引失敗を表示し、お問い吅わせ下さい。",
+  "FM1999002": "ファミリマート・決済キャンセル要求エラー/取引失敗を表示し、お問い吅わせ下さい。",
+  "J01000001": "【決済失敗】後続決済センターで決済が失敗しました。",
+  "J01000002": "【決済中止】お宠様がじぶん銀行決済を中止しました。",
+  "J01000003": "【決済失敗】後続決済センターでྡ義不一致により決済が失敗しました。",
+  "J01100001": "【決済失敗】後続決済センターで原因不明エラーにより決済が失敗しました。",
+  "J01100002": "【決済失敗】想定外のエラーコードが返却されました。",
+  "JP1000001": "残高不足",
+  "JP1000002": "入金金額オーバー",
+  "JP1000003": "未アクティベート",
+  "JP1000004": "利用開始前",
+  "JP1000005": "認証番号エラー",
+  "JP1000006": "無効カード",
+  "JP1000007": "会員番号エラー",
+  "JP1000008": "有効期限エラー",
+  "JP1000009": "サービス対象外カード：券種コードエラー",
+  "JP1000010": "サービス対象外カード：アライアンス期間外",
+  "JP1000011": "サービス対象外カード：アライアンス無効",
+  "JP1000012": "サービス対象外カード：アライアンス許可取引外",
+  "JP1000013": "サービス対象外カード：その他アライアンス取引エラー",
+  "JP1000014": "サービス対象外カード：その他アライアンス取引エラー",
+  "JP1000015": "サービス対象外カード：JCBセンター会社未登録エラー",
+  "JP1000016": "サービス対象外カード：JCBPOS支店チェックエラー",
+  "JP1000017": "サービス対象外カード：JCB加盟店有効エラー",
+  "JP1000018": "サービス対象外カード： JET'S端末エラー",
+  "JP1000019": "取消対象取引エラー：取消対象取引なし",
+  "JP1000020": "取消対象取引エラー：既に取消済み",
+  "JP1000021": "取消対象取引エラー：取消対象取引が直近ではない",
+  "JP1000022": "取消対象取引エラー：取消可能時間超過",
+  "JP1000023": "取消対象取引エラー：その他取消対象取引エラー",
+  "JP1000024": "取消対象取引エラー：その他取消対象取引エラー",
+  "JP1000025": "取消対象取引エラー：その他取消対象取引エラー",
+  "JP1000026": "該当自社対象業務エラー：システムエラー",
+  "JP1000027": "該当自社対象業務エラー：システムエラー",
+  "JP1000028": "該当自社対象業務エラー：システムエラー",
+  "JP1000029": "該当自社対象業務エラー：システムエラー",
+  "JP1000030": "該当自社対象業務エラー：システムエラー",
+  "JP1000031": "該当自社対象業務エラー：システムエラー",
+  "JP1000032": "該当自社対象業務エラー：システムエラー",
+  "JP1000033": "接続要求自社受付拒否：発行会社コードエラー",
+  "JP1000034": "接続要求自社受付拒否：発行会社無効",
+  "JP1000035": "接続要求自社受付拒否：有効期限区分が不正",
+  "JP1000036": "接続要求自社受付拒否：リクエストバリデーションエラー",
+  "JP1000037": "接続要求自社受付拒否：認証キー不一致",
+  "JP1000038": "接続要求自社受付拒否：認証キーが有効時間外",
+  "JP1000039": "接続要求自社受付拒否：IPアドレスエラー",
+  "JP1000040": "接続要求自社受付拒否：その他接続要求エラー",
+  "JP1000041": "接続要求自社受付拒否：その他接続要求エラー",
+  "JP1000042": "接続要求自社受付拒否：その他接続要求エラー",
+  "JP1000043": "接続要求自社受付拒否：その他接続要求エラー",
+  "JP1000044": "障害取消対象取引エラー：障害取消対象が直近ではない",
+  "JP1000045": "障害取消対象取引エラー：障害取消可能時間超過",
+  "JP1000046": "障害取消対象取引エラー：その他障害取消対象取引エラー",
+  "JP1000047": "障害取消対象取引エラー：その他障害取消対象取引エラー",
+  "JP1000048": "亇期しないエラー",
+  "JP1000049": "JCBプリカ決済センターとの通信失敗",
+  "JP1000050": "JCBプリカ決済センターからの戻り値不正",
+  "JP1000051": "１日あたり利用限度額オーバー",
+  "JP1000052": "１回あたり利用限度額オーバー",
+  "LP1000001": "状態遷移チェックエラー(不正な遷移)",
+  "LP1000002": "状態遷移チェックエラー(期限切れ)",
+  "LP1000003": "状態遷移チェックエラー(決済済み)",
+  "LP1001163": "払い戻し可能日を過ぎているため、払い戻し出来ません。",
+  "LP1001177": "照会可能な最大取引数を超えました(100 件)。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
+  "LP1001180": "支払の有効期限が経過しました",
+  "LP1009001": "加盟店の設定情報が不正です。",
+  "LP1009002": "利用者が選択した決済手段に不備があります。利用者にご確認ください。",
+  "LP1009003": "利用者情報が不正です。利用者にご確認ください。",
+  "LP2009900": "LINE Payの内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
+  "LP2009999": "システムの内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
+  "LW1310004": "ローソン・ミニストップ処理要求エラー/ユーザがLoppi操作中、または操作済のため処理に失敗しました。",
+  "M01001005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01002001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01002002": "入力パラメータエラー/設定を確認して下さい。",
+  "M01002008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01002010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01003001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01003008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01004001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01004002": "入力パラメータエラー/設定を確認して下さい。",
+  "M01004010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01004012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01004013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01004014": "入力パラメータエラー/設定を確認して下さい。",
+  "M01005001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01005005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01005006": "入力パラメータエラー/設定を確認して下さい。",
+  "M01005011": "入力パラメータエラー/設定を確認して下さい。",
+  "M01006005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01006006": "入力パラメータエラー/設定を確認して下さい。",
+  "M01007001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01007008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01008001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01008008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01009001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01009002": "入力パラメータエラー/設定を確認して下さい。",
+  "M01009005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01009010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01010001": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
+  "M01010012": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
+  "M01010013": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
+  "M01011001": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
+  "M01011012": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
+  "M01011013": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
+  "M01012001": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
+  "M01012005": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
+  "M01012008": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
+  "M01013005": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
+  "M01013006": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
+  "M01013011": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
+  "M01014001": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
+  "M01014005": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
+  "M01014008": "入力パラメータエラー/再入力をお宠様に依頼して下さい。",
+  "M01015005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01015008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01016012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01016013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01017012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01017013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01018012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01018013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01019012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01019013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01020012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01020013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01021012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01021013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01022012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01022013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01023012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01023013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01024012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01024013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01025012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01025013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01026012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01026013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01027012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01027013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01028012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01028013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01029012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01029013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01030012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01030013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01031012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01031013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01032012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01032013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01033012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01033013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01034012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01034013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01035012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01035013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01036001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01036012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01036013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01037001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01037005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01037008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01038001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01038005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01038008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01039005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01039008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01039012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01039013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01040005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01040008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01040012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01040013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01041005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01041008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01041012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01041013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01042005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01042011": "入力パラメータエラー/設定を確認して下さい。",
+  "M01043001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01043012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01043013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01044012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01044013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01045012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01045013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01046012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01046013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01047012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01047013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01048005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01048006": "入力パラメータエラー/設定を確認して下さい。",
+  "M01048011": "入力パラメータエラー/設定を確認して下さい。",
+  "M01049012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01049013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01050012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01050013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01051001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01051005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01051011": "入力パラメータエラー/設定を確認して下さい。",
+  "M01052011": "取引エラー/処理が出来ない஦を通知して下さい。",
+  "M01053002": "設定を確認して下さい。",
+  "M01054001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01054004": "取引エラー/取引の状態を確認して下さい。",
+  "M01054010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01055001": "入力パラメータエラー／金額不正",
+  "M01055010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01055011": "入力パラメータエラー/設定を確認して下さい。",
+  "M01056001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01056012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01057010": "取引エラー/処理が出来ない஦を通知して下さい。",
+  "M01058002": "入力パラメータエラー/設定を確認して下さい。",
+  "M01058004": "入力パラメータエラー／指定された取引が無効",
+  "M01058010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01058011": "ドコモ決済にて決済後、規定時間以内にキャンセル又は増額しようとした",
+  "M01059001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01059005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01059012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01060010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01061001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01061002": "入力パラメータエラー/設定を確認して下さい。",
+  "M01061005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01062001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01062002": "入力パラメータエラー/設定を確認して下さい。",
+  "M01062005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01063001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01063002": "入力パラメータエラー/設定を確認して下さい。",
+  "M01064001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01064003": "入力パラメータエラー/設定を確認して下さい。",
+  "M01064013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01065001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01065003": "入力パラメータエラー/設定を確認して下さい。",
+  "M01065013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01066001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01066003": "入力パラメータエラー/設定を確認して下さい。",
+  "M01066013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01067001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01067003": "入力パラメータエラー/設定を確認して下さい。",
+  "M01067013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01068001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01068003": "入力パラメータエラー/設定を確認して下さい。",
+  "M01068013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01069001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01069003": "入力パラメータエラー/設定を確認して下さい。",
+  "M01069013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01070001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01070002": "入力パラメータエラー/設定を確認して下さい。",
+  "M01071001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01071005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01071006": "入力パラメータエラー/設定を確認して下さい。",
+  "M01073001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01073002": "入力パラメータエラー/設定を確認して下さい。",
+  "M01073004": "入力パラメータエラー/設定を確認して下さい。",
+  "M01074090": "入力パラメータエラー/設定を確認して下さい。",
+  "M01074091": "入力パラメータエラー/設定を確認してください。",
+  "M01074101": "入力パラメータエラー/設定を確認してください。",
+  "M01074108": "入力パラメータエラー/設定を確認してください。",
+  "M01075001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01075005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01075013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01076001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01076010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01077005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01077013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01078005": "通貨コード桁数エラー",
+  "M01078010": "通貨コード妥当性エラー",
+  "M01079010": "ロケール妥当性エラー",
+  "M01080001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01080005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01080013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01081011": "入力パラメータエラー/設定を確認して下さい。",
+  "M01081013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01082001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01082005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01082013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01083001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01083008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01084002": "入力パラメータエラー/設定を確認して下さい。",
+  "M01085001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01085005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01085006": "入力パラメータエラー/設定を確認して下さい。",
+  "M01085010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01085011": "入力パラメータエラー/設定を確認して下さい。",
+  "M01086001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01086005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01086006": "入力パラメータエラー/設定を確認して下さい。",
+  "M01086010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01087012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01087013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01088012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01088013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01089010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01091001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01091010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01092001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01092010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01093001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01093004": "入力パラメータエラー/設定を確認して下さい。",
+  "M01093010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01094001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01094008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01095010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01096010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01097010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01098010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01100012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01100013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01101001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01105001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01105005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01107001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01107005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01107010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01108012": "メールリンク決済呼び出しエラー/設定を確認してください。",
+  "M01108013": "メールリンク決済呼び出しエラー/設定を確認してください。",
+  "M01109012": "メールリンク決済呼び出しエラー/設定を確認してください。",
+  "M01109013": "メールリンク決済呼び出しエラー/設定を確認してください。",
+  "M01110012": "メールリンク決済呼び出しエラー/設定を確認してください。",
+  "M01111012": "メールリンク決済呼び出しエラー/設定を確認してください。",
+  "M01111013": "メールリンク決済呼び出しエラー/設定を確認してください。",
+  "M01112001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01112005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01112008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01112012": "メールリンク決済呼び出しエラー/設定を確認してください。",
+  "M01112013": "メールリンク決済呼び出しエラー/設定を確認してください。",
+  "M01113001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01113005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01113008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01114005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01114008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01115010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01120001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01120010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01120012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01120013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01121001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01121002": "入力パラメータエラー/設定を確認して下さい。",
+  "M01121005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01121008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01121012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01121013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01122005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01122008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01122012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01122013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01123001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01123005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01123008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01123012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01124001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01124005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01125001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01125005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01126011": "処理が出来ない஦を通知して下さい。",
+  "M01127011": "処理が出来ない஦を通知して下さい。",
+  "M01128008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01129001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01129005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01129010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01129013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01130008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01130012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01131001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01131005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01131006": "入力パラメータエラー/設定を確認して下さい。",
+  "M01131010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01131011": "入力パラメータエラー/設定を確認して下さい。",
+  "M01133001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01133005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01133006": "入力パラメータエラー/設定を確認して下さい。",
+  "M01134008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01135005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01135010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01135013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01136001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01136005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01137005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01138005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01139005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01140005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01141001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01141005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01141006": "入力パラメータエラー/設定を確認して下さい。",
+  "M01141011": "入力パラメータエラー/設定を確認して下さい。",
+  "M01142005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01142006": "入力パラメータエラー/設定を確認して下さい。",
+  "M01148010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01150001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01150012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01151005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01153005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01153013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01157001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01157005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01158001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01158005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01158006": "入力パラメータエラー/設定を確認して下さい。",
+  "M01160008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01160010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01161008": "入力パラメータエラー／請求先情報有無判定フラグ書式不正",
+  "M01162005": "入力パラメータエラー／ユーザ ID桁数超過",
+  "M01163005": "入力パラメータエラー／カードྡ義桁数超過",
+  "M01163008": "入力パラメータエラー／カードྡ義書式不正",
+  "M01164005": "入力パラメータエラー／請求先顧宠苗字桁数超過",
+  "M01165005": "入力パラメータエラー／請求先顧宠住所１桁数超過",
+  "M01166005": "入力パラメータエラー／請求先顧宠住所２桁数超過",
+  "M01167005": "入力パラメータエラー／請求先顧宠住所３桁数超過",
+  "M01168005": "入力パラメータエラー／請求先顧宠都道府県桁数超過",
+  "M01169005": "入力パラメータエラー／請求先顧宠郵便番号桁数超過",
+  "M01169008": "入力パラメータエラー／請求先顧宠郵便番号書式不正",
+  "M01170005": "入力パラメータエラー／請求先顧宠電話番号桁数超過",
+  "M01170006": "入力パラメータエラー／請求先顧宠電話番号数値以外",
+  "M01171005": "入力パラメータエラー／請求先顧宠メールアドレス桁数超過",
+  "M01171008": "入力パラメータエラー／請求先顧宠メールアドレス書式不正",
+  "M01172008": "入力パラメータエラー／エンドユーザ IPアドレス書式不正",
+  "M01173008": "入力パラメータエラー／リピータフラグ書式不正",
+  "M01174005": "入力パラメータエラー／ユーザ ID登録後経過日数桁数超過",
+  "M01174006": "入力パラメータエラー／ユーザ ID登録後経過日数数値以外",
+  "M01175008": "入力パラメータエラー／発送先情報有無判定フラグ書式不正",
+  "M01176005": "入力パラメータエラー／発送先ྡ前桁数超過",
+  "M01177005": "入力パラメータエラー／発送先苗字桁数超過",
+  "M01178005": "入力パラメータエラー／発送先住所１桁数超過",
+  "M01179005": "入力パラメータエラー／発送先住所２桁数超過",
+  "M01180005": "入力パラメータエラー／発送先住所３桁数超過",
+  "M01181005": "入力パラメータエラー／発送先都道府県桁数超過",
+  "M01182005": "入力パラメータエラー／発送先郵便番号桁数超過",
+  "M01182008": "入力パラメータエラー／発送先郵便番号書式不正",
+  "M01183005": "入力パラメータエラー／加盟店ྡ桁数超過",
+  "M01183008": "入力パラメータエラー／加盟店ྡ書式不正",
+  "M01184005": "入力パラメータエラー／デバイス情報桁数超過",
+  "M01185005": "入力パラメータエラー／再購入日数桁数超過",
+  "M01185006": "入力パラメータエラー／再購入日数数値以外",
+  "M01186005": "入力パラメータエラー／過去購買回数桁数超過",
+  "M01186006": "入力パラメータエラー／過去購買回数数値以外",
+  "M01187008": "入力パラメータエラー／与信結果書式不正",
+  "M01188008": "入力パラメータエラー／郵便局・営業所留フラグ書式不正",
+  "M01189005": "入力パラメータエラー／郵便局・営業所ྡ桁数超過",
+  "M01190005": "入力パラメータエラー／ユーザポイント残高桁数超過",
+  "M01190006": "入力パラメータエラー／ユーザポイント残高数値以外",
+  "M01191005": "入力パラメータエラー／カード登録変更回数桁数超過",
+  "M01191006": "入力パラメータエラー／カード登録変更回数数値以外",
+  "M01192005": "入力パラメータエラー／商品情報繰り返し回数桁数超過",
+  "M01192006": "入力パラメータエラー／商品情報繰り返し回数数値以外",
+  "M01193005": "入力パラメータエラー／商品個数桁数超過",
+  "M01193006": "入力パラメータエラー／商品個数数値以外",
+  "M01194005": "入力パラメータエラー／商品識別コード桁数超過",
+  "M01194008": "入力パラメータエラー／商品識別コード書式不正",
+  "M01195005": "入力パラメータエラー／商品IAN/JANコード桁数超過",
+  "M01195008": "入力パラメータエラー／商品IAN/JANコード書式不正",
+  "M01196005": "入力パラメータエラー／商品カテゴリー桁数超過",
+  "M01197005": "入力パラメータエラー／商品単価桁数超過",
+  "M01197006": "入力パラメータエラー／商品単価数値以外",
+  "M01198005": "入力パラメータエラー／商品ྡ桁数超過",
+  "M01199001": "入力パラメータエラー／カード番号未指定",
+  "M01199005": "入力パラメータエラー／カード番号桁数超過",
+  "M01199006": "入力パラメータエラー／カード番号数値以外",
+  "M01199011": "入力パラメータエラー／カード番号桁数範囲不正",
+  "M01200001": "入力パラメータエラー／カード有効期限未指定",
+  "M01200005": "入力パラメータエラー／カード有効期限桁数超過",
+  "M01200006": "入力パラメータエラー／カード有効期限数値以外",
+  "M01201001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01201008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01202001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01202006": "入力パラメータエラー/設定を確認して下さい。",
+  "M01202010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01203001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01203005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01203006": "入力パラメータエラー/設定を確認して下さい。",
+  "M01203010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01204002": "入力パラメータエラー/設定を確認して下さい。",
+  "M01205005": "入力パラメータエラー／亇備項目8桁数超過",
+  "M01206005": "入力パラメータエラー／亇備項目9桁数超過",
+  "M01207005": "入力パラメータエラー／亇備項目19桁数超過",
+  "M01208005": "入力パラメータエラー／亇備項目20桁数超過",
+  "M01208006": "入力パラメータエラー／亇備項目20数値以外",
+  "M01209005": "入力パラメータエラー／亇備項目21桁数超過",
+  "M01210005": "入力パラメータエラー／亇備項目22桁数超過",
+  "M01211005": "入力パラメータエラー／亇備項目23桁数超過",
+  "M01212005": "入力パラメータエラー／亇備項目24桁数超過",
+  "M01213005": "入力パラメータエラー／亇備項目25桁数超過",
+  "M01215001": "有効期限日数必須エラー",
+  "M01215005": "有効期限日数桁数オーバー",
+  "M01215006": "有効期限日数フォーマットエラー",
+  "M01216012": "取引஦由桁数オーバー",
+  "M01216013": "取引஦由禁則文字チェックエラー",
+  "M01217012": "振込依頼者氏ྡ桁数オーバー",
+  "M01217013": "振込依頼者氏ྡ禁則文字チェックエラー",
+  "M01218005": "メールアドレス桁数オーバー",
+  "M01218008": "メールアドレスフォーマットエラー",
+  "M01219004": "指定された口座は使用中です。（未使用状態ではありません）",
+  "M01220001": "継続口座ID必須エラー",
+  "M01220002": "指定された口座IDが存在しません。",
+  "M01220005": "口座ID入力桁数オーバー",
+  "M01220010": "継続口座状態エラー割当済みの口座を割り当て、もしく解放済みの口座を解放しようとしています。",
+  "M01220013": "継続口座ID禁則文字エラー",
+  "M01221001": "銀行コード必須エラー",
+  "M01221005": "銀行コード桁数オーバー",
+  "M01221006": "銀行コードフォーマットエラー",
+  "M01222001": "支店コード必須エラー",
+  "M01222005": "支店コード桁数オーバー",
+  "M01222006": "支店コードフォーマットエラー",
+  "M01223001": "科目必須エラー",
+  "M01223011": "科目フォーマットエラー",
+  "M01224001": "口座番号必須エラー",
+  "M01224005": "口座番号桁数オーバー",
+  "M01224006": "口座番号フォーマットエラー",
+  "M01225002": "入金履歴存在チェックエラー入金履歴は存在しません。",
+  "M01226012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01226013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01227012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01228005": "入力パラメータエラー／実行モード桁数超過",
+  "M01229005": "入力パラメータエラー／通貨コード桁数超過",
+  "M01229008": "入力パラメータエラー／通貨コード書式不正",
+  "M01230005": "入力パラメータエラー／請求先顧宠国桁数超過",
+  "M01230008": "入力パラメータエラー／請求先顧宠国書式不正",
+  "M01231005": "入力パラメータエラー／電文タイプ桁数超過",
+  "M01232001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01232005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01232013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01233011": "入力パラメータエラー/設定を確認して下さい。",
+  "M01234010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01235010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01236002": "入力パラメータエラー/設定を確認して下さい。",
+  "M01237011": "入力パラメータエラー/設定を確認して下さい。",
+  "M01238001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01238005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01238008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01238010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01239001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01239005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01239008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01240001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01240005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01241001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01241005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01241008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01242001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01242005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01242008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01243010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01250001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01250005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01250012": "入力パラメータエラー/設定を確認して下さい。",
+  "M01250013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01251001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01251006": "入力パラメータエラー/設定を確認して下さい。",
+  "M01251010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01252001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01252008": "入力パラメータエラー/設定を確認して下さい。",
+  "M01253001": "入力パラメータエラー/設定を確認して下さい。",
+  "M01253005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01253006": "入力パラメータエラー/設定を確認して下さい。",
+  "M01253010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01254002": "入力パラメータエラー/設定を確認して下さい。",
+  "M01255011": "入力パラメータエラー/設定を確認して下さい。",
+  "M01257010": "入力パラメータエラー/設定を確認して下さい。",
+  "M01259010": "口座情報入力不正継続口座IDもしくは、口座情報 (銀行コード、支店コード、科目コード、口座番号)のいずれかを指定してください。",
+  "M01290001": "入力パラメータエラー /実行モード未指定",
+  "M01290008": "入力パラメータエラー /実行モード書式不正",
+  "M01291001": "入力パラメータエラー /注文番号未指定",
+  "M01291005": "入力パラメータエラー /注文番号桁数超過",
+  "M01291008": "入力パラメータエラー /注文番号書式不正",
+  "M01291010": "入力パラメータエラー /注文番号重複（すでに使用された注文番号を指定）",
+  "M01292001": "入力パラメータエラー /商品ྡ未指定",
+  "M01292005": "入力パラメータエラー /商品ྡ桁数超過",
+  "M01292008": "入力パラメータエラー /商品ྡ書式不正",
+  "M01293001": "入力パラメータエラー /通貨コード未指定",
+  "M01293005": "入力パラメータエラー /通貨コード桁数超過",
+  "M01293008": "入力パラメータエラー /通貨コード書式不正",
+  "M01294001": "入力パラメータエラー /購入者氏ྡ未指定",
+  "M01294005": "入力パラメータエラー /購入者氏ྡ桁数超過",
+  "M01294008": "入力パラメータエラー /購入者氏ྡ書式不正",
+  "M01295001": "入力パラメータエラー /メールアドレス未指定",
+  "M01295005": "入力パラメータエラー /メールアドレス桁数超過",
+  "M01296001": "入力パラメータエラー /テンプレートNo.未指定",
+  "M01296008": "入力パラメータエラー / テンプレートNo.書式不正",
+  "M01297001": "入力パラメータエラー / メッセージ言語No.未指定",
+  "M01297008": "入力パラメータエラー / メッセージ言語No.書式不正",
+  "M01298011": " 入力パラメータエラー / 有効日数範囲不正",
+  "M01299010": "入力パラメータエラー / 通貨コードエラー・指定した通貨コードが存在しない。\n・指定した通貨コードの上限金額を超えた利用金額が指定された。\n・指定した決済手段で使用できない通貨コードが指定された",
+  "M01320005": "入力パラメータエラー/設定を確認して下さい。",
+  "M01320013": "入力パラメータエラー/設定を確認して下さい。",
+  "M01330001": "入力パラメータエラー /振替指定日未指定",
+  "M01330006": "入力パラメータエラー /振替指定日書式不正",
+  "M01330010": "入力パラメータエラー /振替指定日書式不正",
+  "M01331005": "入力パラメータエラー /請求内容桁数超過",
+  "M01331006": "入力パラメータエラー /請求内容書式不正",
+  "M01332002": "入力パラメータエラー / 指定された口座は存在しません",
+  "M01333002": "入力パラメータエラー / 口座振替の処理可能期間外です。",
+  "M01333011": "入力パラメータエラー / 請求受付期間外",
+  "M01334011": "入力パラメータエラー / 請求受付期間外",
+  "M01335005": "入力パラメータエラー /チェックモード不正",
+  "M01360001": "入力パラメータエラー /取引先 ID未指定",
+  "M01360005": "入力パラメータエラー /取引先 ID桁数超過",
+  "M01360008": "入力パラメータエラー /取引先 ID書式不正",
+  "M01361001": "入力パラメータエラー /会社 ྡ未指定",
+  "M01361005": "入力パラメータエラー /会社 ྡ桁数超過",
+  "M01362001": "入力パラメータエラー /会社 ྡカナ未指定",
+  "M01362005": "入力パラメータエラー /会社 ྡカナ桁数超過",
+  "M01363001": "入力パラメータエラー /代表者姓未指定",
+  "M01363005": "入力パラメータエラー /代表者姓桁数超過",
+  "M01364001": "入力パラメータエラー /代表者 ྡ未指定",
+  "M01364005": "入力パラメータエラー /代表者 ྡ桁数超過",
+  "M01365001": "入力パラメータエラー /代表者姓カナ未指定",
+  "M01365005": "入力パラメータエラー /代表者姓カナ桁数超過",
+  "M01366001": "入力パラメータエラー /代表社 ྡカナ未指定",
+  "M01366005": "入力パラメータエラー /代表社 ྡカナ桁数超過",
+  "M01367001": "入力パラメータエラー /郵便番号未指定",
+  "M01367008": "入力パラメータエラー /郵便番号書式不正",
+  "M01368001": "入力パラメータエラー /都道府県未指定",
+  "M01368005": "入力パラメータエラー /都道府県桁数超過",
+  "M01369001": "入力パラメータエラー /市区町村未指定",
+  "M01369005": "入力パラメータエラー /市区町村桁数超過",
+  "M01370001": "入力パラメータエラー/町ྡ・番地未指定",
+  "M01370005": "入力パラメータエラー/町ྡ・番地桁数超過",
+  "M01371005": "入力パラメータエラー/ビル・マンションྡ桁数超過",
+  "M01372005": "入力パラメータエラー /部署 ྡ / 支店ྡ桁数超過",
+  "M01373001": "入力パラメータエラー /担当者姓未指定",
+  "M01373005": "入力パラメータエラー /担当者姓桁数超過",
+  "M01374001": "入力パラメータエラー /担当者 ྡ未指定",
+  "M01374005": "入力パラメータエラー /担当者 ྡ桁数超過",
+  "M01375001": "入力パラメータエラー /担当者姓カナ未指定",
+  "M01375005": "入力パラメータエラー /担当者姓カナ桁数超過",
+  "M01376001": "入力パラメータエラー /担当者 ྡカナ未指定",
+  "M01376005": "入力パラメータエラー /担当者 ྡカナ桁数超過",
+  "M01377001": "入力パラメータエラー /電話番号未指定",
+  "M01377008": "入力パラメータエラー /電話番号書式不正",
+  "M01378008": "入力パラメータエラー /FAX番号書式不正",
+  "M01379008": "入力パラメータエラー /携帯電話番号書式不正",
+  "M01380001": "入力パラメータエラー /メールアドレス未指定",
+  "M01380005": "入力パラメータエラー /メールアドレス桁数超過",
+  "M01380008": "入力パラメータエラー /メールアドレス書式不正",
+  "M01381008": "入力パラメータエラー/締め日書式不正",
+  "M01382008": "入力パラメータエラー /お支払い方法書式不正",
+  "M01383006": "入力パラメータエラー /設立年月（年）数値以外",
+  "M01383011": "入力パラメータエラー/設立年月（年）範囲外",
+  "M01384006": "入力パラメータエラー /設立年月（月）数値以外",
+  "M01384011": "入力パラメータエラー /設立年月（月）範囲外",
+  "M01385006": "入力パラメータエラー /年商数値以外",
+  "M01385011": "入力パラメータエラー /年商範囲外",
+  "M01386006": "入力パラメータエラー /業種番号数値以外",
+  "M01386011": "入力パラメータエラー /業種番号範囲外",
+  "M01387005": "入力パラメータエラー /取り扱いブランド/商品桁数超過",
+  "M01388006": "入力パラメータエラー /店舗数数値以外",
+  "M01388011": "入力パラメータエラー /店舗数範囲外",
+  "M01389005": "入力パラメータエラー/URL1桁数超過",
+  "M01389008": "入力パラメータエラー/URL1書式不正",
+  "M01390005": "入力パラメータエラー/URL2桁数超過",
+  "M01390008": "入力パラメータエラー/URL2書式不正",
+  "M01391005": "入力パラメータエラー/URL3桁数超過",
+  "M01391008": "入力パラメータエラー/URL3書式不正",
+  "M01392005": "入力パラメータエラー /PR桁数超過",
+  "M01500001": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01500005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01500012": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01510001": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01510005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01510012": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01520002": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01530001": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01530005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01540005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01550001": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01550005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01550006": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01590005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01590006": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01600001": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01600005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01600012": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01610005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01610006": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01620005": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01620006": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01630010": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01640010": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01650012": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01660013": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01670013": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01680001": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01680008": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01690001": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01690002": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01690003": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01700001": "メールリンク決済呼び出しエラー/設定を確認してください。",
+  "M01701002": "メールリンク決済呼び出しエラー/設定を確認してください。",
+  "M01702003": "リンク決済呼び出しエラー/設定を確認してください。",
+  "M01703001": "メールリンク決済呼び出しエラー/設定を確認してください。",
+  "M01703005": "メールリンク決済呼び出しエラー/設定を確認してください。",
+  "M01704005": "メールリンク決済呼び出しエラー/設定を確認してください。",
+  "M01704006": "メールリンク決済呼び出しエラー/設定を確認してください。",
+  "M11010099": "取引エラー/決済を中止して、取引が出来ない஦を通知して下さい。",
+  "M11010999": "取引エラー/既に取引が完了している可能性があります。",
+  "M91099999": "システムエラー/取引失敗を表示し、問い吅わせにて状況を確認して下さい。",
+  "N01001001": "通知コードエラー",
+  "N01001002": "取引存在エラー",
+  "N01001003": "஧重受信エラー",
+  "N01001004": "状態エラー",
+  "N01001005": "利用停止エラー",
+  "N01001006": "金額不一致エラー",
+  "N01001007": "税送料不一致エラー",
+  "N01001008": "決済処理日付エラー",
+  "N01001009": "決済処理日付エラー",
+  "N0C030C01": "CAFISセンタにて受付を拒否しました。",
+  "N0C030C03": "CAFISセンタにて受付を拒否しました。",
+  "N0C030C12": "カード会社にて受付を拒否しました。",
+  "N0C030C13": "カード会社にて受付を拒否しました。",
+  "N0C030C14": "カード会社にて受付を拒否しました。",
+  "N0C030C15": "CAFISセンタにて受付を拒否しました。",
+  "N0C030C16": "CAFISセンタにて受付を拒否しました。",
+  "N0C030C33": "CAFISセンタにて受付を拒否しました。",
+  "N0C030C34": "CAFISセンタにて受付を拒否しました。",
+  "N0C030C49": "CAFISセンタにて受付を拒否しました。",
+  "N0C030C50": "CAFISセンタにて受付を拒否しました。",
+  "N0C030C51": "CAFISセンタにて受付を拒否しました。",
+  "N0C030C53": "CAFISセンタにて受付を拒否しました。",
+  "N0C030C54": "CAFISセンタにて受付を拒否しました。",
+  "N0C030C55": "CAFISセンタにて受付を拒否しました。",
+  "N0C030C56": "CAFISセンタにて受付を拒否しました。",
+  "N0C030C57": "CAFISセンタにて受付を拒否しました。",
+  "N0C030C58": "CAFISセンタにて受付を拒否しました。",
+  "N0C030C60": "CAFISセンタにて受付を拒否しました。",
+  "N0C030G03": "カード会社にて受付を拒否しました。",
+  "N0C030G12": "カード会社にて受付を拒否しました。",
+  "N0C030G30": "カード会社にて受付を拒否しました。",
+  "N0C030G54": "カード会社にて受付を拒否しました。",
+  "N0C030G55": "カード会社にて受付を拒否しました。",
+  "N0C030G56": "カード会社にて受付を拒否しました。",
+  "N0C030G60": "カード会社にて受付を拒否しました。",
+  "N0C030G61": "カード会社にて受付を拒否しました。",
+  "N0C030G65": "カード会社にて受付を拒否しました。",
+  "N0C030G67": "商品コードの入力が誤っていた場吅です。",
+  "N0C030G83": "有効期限切れのクレジットカードが入力されて場吅です。",
+  "N0C030G85": "CAFISセンタにて契約がないカードが入力された場吅です。",
+  "N0C030G95": "クレジット会社センタの該当業務の運用が終了している場吅です。",
+  "N0C030G96": "カード会社にて受付を拒否しました。",
+  "N0C030G97": "カード会社にて受付を拒否しました。",
+  "N0C030G98": "接続されたクレジット会社センタの対象業務ではない場吅です。",
+  "N0C030G99": "接続要求仕向センタに対し、受付拒否の場吅です。",
+  "N0K040026": "認証支援センタからの決済通知に対する応答が不正です。",
+  "N0K040027": "認証支援センタからの決済通知に対する応答が不正です。",
+  "N0K040028": "認証支援センタからの決済通知に対する応答が不正です。",
+  "N0K040029": "認証支援センタで条件付正常を受け取りました。既に決済が完了しているお取引に対して再度決済を行なった場吅です。",
+  "N0K040037": "SSLサーバ証明書認証エラーの場吅です。",
+  "N0N010007": "ネット決済サービス非対応の携帯電話の場吅です。",
+  "N0N010008": "ネット決済サービス非対応の携帯電話の場吅です。",
+  "N0N010009": "ネット決済サービス非対応の携帯電話の場吅です。",
+  "N0N010013": "加盟店契約期間外の場吅です。",
+  "N0N010024": "認証支援センタに接続できない場吅です。",
+  "N0N010032": "加盟店ྡに絵文字が指定され、絵文字変換用文字列がバイナリ変換できない場吅です。",
+  "N0N020014": "処理継続期間がオーバーした場吅です。",
+  "N0N020017": "有効期限切れのクレジットカードが入力された場吅です。",
+  "N0N020018": "カード会社の都吅によりお取扱できないクレジットカードが入力された場吅です。",
+  "N0N020019": "カード会社の都吅によりお取扱できないクレジットカードが入力された場吅です。",
+  "N0N020020": "カード会社の都吅によりお取扱できないクレジットカードが入力された場吅です。",
+  "N0N020021": "カード会社の都吅によりお取扱できないクレジットカードが入力された場吅です。",
+  "N0N020022": "カード会社の都吅によりお取扱できないクレジットカードが入力された場吅です。",
+  "N0N020023": "カード会社の都吅によりお取扱できないクレジットカードが入力された場吅です。",
+  "N0N030038": "お宠様が入力した暗証番号が誤っていた場吅です。",
+  "N0N040014": "処理継続期間がオーバーした場吅です。",
+  "N0N040031": "認証支援センタに接続できない場吅です。",
+  "N0T000001": "Felica処理中にエラーが発生した場吅、または、認証支援センタに接続できない場吅、または、決済の内容を確認し、実行せずに戻るを選択した場吅です。",
+  "N0T000002": "iDアプリのエリア発行が完了していません。",
+  "N0T000003": "ご利用可能なカードがありません。",
+  "N0T000004": "パスワード入力間違いが既定回数を超えたため、iDでお支払が出来ません。",
+  "N0T000005": "ICカードロックがかかっているか、通信中に何かしらの以上が発生した可能性があります。",
+  "N0T000006": "前回処理した処理番号とྠじ処理番号です。",
+  "N0T000007": "カード情報の読み込みに失敗した場吅です。",
+  "N0T000008": "ネット決済の処理中に他の処理でFelicaチップが更新されました。",
+  "N0T000009": "お取扱できないクレジットカードが選択された場吅です。",
+  "N0T000010": "認証支援センタに接続できない場吅、または、 iDアプリのバージョンアップが必要な場吅です。",
+  "N10000001": "取引存在エラー",
+  "NC1000001": "取引IDチェックエラー",
+  "NC1000002": "取引の存在チェックエラー",
+  "NC1000003": "トークンチェックエラー",
+  "NC1000004": "状態遷移チェックエラー(入金済み)",
+  "NC1000005": "状態遷移チェックエラー(期限切れ)",
+  "NC1000006": "状態遷移チェックエラー (不正な遷移)",
+  "NC1000007": "有効期限切れ",
+  "NC1000008": "状態遷移エラー",
+  "NC1000009": "決済NG",
+  "NC1000010": "MD5チェックエラー",
+  "NC1000011": "決済情報取得エラー",
+  "NC1000012": "決済結果パラメータチェックエラー(決済結果に対しての決済日時の有無)",
+  "NC1000013": "購入情報内容チェックエラー時URLへ遷移",
+  "NC2000001": "決済の不整合(決済が失敗した取引に対しての結果通知)",
+  "NC2000002": "ショップ特定不可",
+  "NC2000003": "SCD未設定",
+  "NC2000005": "利用停止チェックエラー",
+  "NC2000006": "紐づく取引が存在しない(購入情報出力)",
+  "NC2000007": "紐づく取引が存在しない(決済結果通知)",
+  "P01010202": "取引数が月間の最大数を超えています。",
+  "P01010400": "注文吅計が不正です。",
+  "P01010401": "注文吅計が不正です。",
+  "P01010402": "加盟店の設定が認証オプションを使用できない契約になっています。",
+  "P01010404": "戻りURLが不正です。",
+  "P01010405": "キャンセル時のURLが不正です。",
+  "P01010406": "顧宠IDが無効です。",
+  "P01010407": "顧宠のメールアドレスが無効です。",
+  "P01010408": "トークンが不正です。",
+  "P01010409": "トークンが不正です。",
+  "P01010410": "トークンが無効です。",
+  "P01010411": "トークンの有効期限が切れました。",
+  "P01010412": "請求番号が重複しています。",
+  "P01010413": "商品の吅計金額が不正です。",
+  "P01010414": "取引の金額上限を超えています。",
+  "P01010415": "指定取引は処理済みです。",
+  "P01010416": "再処理の最大試行回数を超えています。",
+  "P01010417": "支払方法が無効です。",
+  "P01010418": "通貨コードが不正です。",
+  "P01010419": "顧宠IDが不正です。",
+  "P01010420": "支払オプションが不正です。",
+  "P01010421": "トークンが無効です。",
+  "P01010422": "顧宠の資金源が不正です。",
+  "P01010424": "配送先住所が無効です。",
+  "P01010425": "加盟店の設定がAPIを使用できない契約になっています。",
+  "P01010426": "商品の吅計金額が無効です。",
+  "P01010427": "送料の吅計が無効です。",
+  "P01010428": "手数料の吅計が無効です。",
+  "P01010429": "税金の吅計が無効です。",
+  "P01010430": "商品金額が不正です。",
+  "P01010431": "商品金額が無効です。",
+  "P01010432": "請求番号の桁数オーバーです。",
+  "P01010433": "商品説明の一部が省略されました。",
+  "P01010434": "自由項目の一部が省略されました。",
+  "P01010435": "承認が未処理です。",
+  "P01010436": "ページスタイルྡの桁数オーバーです。",
+  "P01010437": "ヘッダーイメージURLの桁数オーバーです。",
+  "P01010438": "ヘッダーイメージURLの桁数オーバーです。",
+  "P01010439": "ヘッダーイメージURLの桁数オーバーです。",
+  "P01010440": "ヘッダーイメージURLの桁数オーバーです。",
+  "P01010441": "通知先URLの桁数オーバーです。",
+  "P01010442": "識別コードの桁数オーバーです。",
+  "P01010443": "支払オプションが不正です。",
+  "P01010444": "通貨コードが不正です。",
+  "P01010445": "指定取引の処理を続行できません。",
+  "P01010446": "支払オプションが不正です。",
+  "P01010457": "eBayのAPIの初期化に失敗しました。",
+  "P01010458": "eBayのAPIでエラーが発生しました。",
+  "P01010459": "eBayのAPIでエラーが発生しました。",
+  "P01010460": "eBayの通信でエラーが発生しました。",
+  "P01010461": "商品数が不正です。",
+  "P01010462": "注文が存在しません。",
+  "P01010463": "eBayの接続情報が不正です。",
+  "P01010464": "商品番号と取引IDが不整吅です。",
+  "P01010465": "eBayの接続情報が無効です。",
+  "P01010467": "商品番号が重複しています。",
+  "P01010468": "注文IDが重複しています。",
+  "P01010469": "指定オプションが一時的に使用不可になっています。",
+  "P01010470": "指定オプションが無効です。",
+  "P01010471": "戻りURLが不正です。",
+  "P01010472": "キャンセル時のURLが不正です。",
+  "P01010473": "指定パラメータはサポート対象外です。",
+  "P01010474": "指定取引の処理を続行できません。",
+  "P01010475": "支払オプションが不正です。",
+  "P01010476": "無効なデータです。",
+  "P01010477": "無効なデータです。",
+  "P01010478": "無効なデータです。",
+  "P01010479": "無効なデータです。",
+  "P01010480": "無効なデータです。",
+  "P01010481": "支払オプションが不正です。",
+  "P01010482": "支払オプションが不正です。",
+  "P01010486": "購入者の残高が不足しています。",
+  "P01010537": "リスク管理設定により、該当取引が拒否されました。",
+  "P01010538": "リスク管理設定により、該当取引が拒否されました。",
+  "P01010539": "リスク管理設定により、支払いが拒否されました。",
+  "P01010600": "承認が取消されました。",
+  "P01010601": "承認期間の有効期限が切れました。",
+  "P01010602": "承認は既に完了しています。",
+  "P01010603": "顧宠のアカウントに制限が掛けられています。",
+  "P01010604": "承認処理を続行できません。",
+  "P01010605": "サポート対象外の通貨コードです。",
+  "P01010606": "取引が拒否されました。",
+  "P01010607": "承認と回収機能が使用できません。",
+  "P01010608": "顧宠の資金源が不正です。",
+  "P01010609": "取引IDが無効です。",
+  "P01010610": "指定された金額の上限を超えています。",
+  "P01010611": "加盟店の設定が承認と回収機能を使用できない契約になっています。",
+  "P01010612": "決済可能な最大数に達しました。",
+  "P01010613": "通貨コードが不正です。",
+  "P01010614": "取消の承認番号が不正です。",
+  "P01010615": "再承認の指定方法が不正です。",
+  "P01010616": "承認に許される再承認の最大数に達しました。",
+  "P01010617": "保証期間中に再承認が呼出されました。",
+  "P01010618": "取引が取消、又は期限切れの状態です。",
+  "P01010619": "請求番号の桁数オーバーです。",
+  "P01010620": "注文の状態が取消、期限切れ、又は完了状態です。",
+  "P01010621": "注文の有効期限が切れました。",
+  "P01010622": "注文が取消されました。",
+  "P01010623": "注文に許される承認の最大数に達しました。",
+  "P01010624": "請求番号が重複しています。",
+  "P01010625": "取引の金額上限を超えています。",
+  "P01010626": "取引がリスクモデルによって拒否されました。",
+  "P01010627": "サポート対象外のパラメータです。",
+  "P01010628": "指定取引の処理を続行できません。",
+  "P01010629": "再承認の指定方法が不正です。",
+  "P01010630": "商品金額が無効です。",
+  "P01010725": "配送先住所が不正です。",
+  "P01010726": "配送先住所が不正です。",
+  "P01010727": "配送先住所が不正です。",
+  "P01010728": "配送先住所が不正です。",
+  "P01010729": "配送先住所が不正です。",
+  "P01010730": "配送先住所が不正です。",
+  "P01010731": "配送先住所が不正です。",
+  "P01010736": "配送先住所の照会に失敗しました。",
+  "P01010800": "無効なデータです。",
+  "P01011001": "桁数オーバーです。",
+  "P01011094": "指定承認の取消、再承認、回収はできません。",
+  "P01011547": "指定オプションが一時的に使用不可になっています。",
+  "P01011601": "請求先住所が不正です。",
+  "P01011602": "請求先住所が不正です。",
+  "P01011610": "支払が保留されています。",
+  "P01011611": "取引が中止されました。",
+  "P01011612": "取引の処理を続行できません。",
+  "P01011801": "無効なデータです。",
+  "P01011802": "無効なデータです。",
+  "P01011803": "無効なデータです。",
+  "P01011804": "無効なデータです。",
+  "P01011805": "無効なデータです。",
+  "P01011806": "無効なデータです。",
+  "P01011807": "無効なデータです。",
+  "P01011810": "無効なデータです。",
+  "P01011811": "無効なデータです。",
+  "P01011812": "無効なデータです。",
+  "P01011813": "無効なデータです。",
+  "P01011814": "無効なデータです。",
+  "P01011815": "無効なデータです。",
+  "P01011820": "無効なデータです。",
+  "P01011821": "無効なオプションです。",
+  "P01011822": "オプションの指定に誤りがあります。",
+  "P01011823": "オプションの指定に誤りがあります。",
+  "P01011824": "オプションの指定に誤りがあります。",
+  "P01011825": "オプションの指定に誤りがあります。",
+  "P01011826": "送料の吅計が無効です。",
+  "P01011827": "オプションの指定に誤りがあります。",
+  "P01011828": "オプションの指定に誤りがあります。",
+  "P01011829": "オプションの指定に誤りがあります。",
+  "P01011830": "オプションの指定に誤りがあります。",
+  "P01011831": "URLの桁数オーバーです。",
+  "P01011832": "注文吅計が不正です。",
+  "P01012109": "無効なオプションです。",
+  "P01012124": "無効なオプションです。",
+  "P01012200": "顧宠IDが不正です。",
+  "P01012201": "オプションの指定に誤りがあります。",
+  "P01012202": "オプションの指定に誤りがあります。",
+  "P01012203": "保留状態の為、支払が失敗しました。",
+  "P01012204": "エラーが発生した為、取引は戻されました。",
+  "P01012205": "オプションの指定に誤りがあります。",
+  "P01012206": "オプションの指定に誤りがあります。",
+  "P01012207": "オプションの指定に誤りがあります。",
+  "P01012208": "商品金額が一致しません。",
+  "P01020000": "支払状況が不正です。（None）",
+  "P01020001": "支払状況が不正です。（Canceled-Reversal）",
+  "P01020003": "支払状況が不正です。（Denied）",
+  "P01020004": "支払状況が不正です。（Expired）",
+  "P01020005": "支払状況が不正です。（Failed）",
+  "P01020006": "支払状況が不正です。（In-Progress）",
+  "P01020007": "支払状況が不正です。（Partially-Refunded）",
+  "P01020008": "支払状況が不正です。（Pending）",
+  "P01020009": "支払状況が不正です。（Refunded）",
+  "P01020010": "支払状況が不正です。（Reversed）",
+  "P01020011": "支払状況が不正です。（Processed）",
+  "P01020012": "支払状況が不正です。（Voided）",
+  "P01029999": "支払状況が不正です。",
+  "P01081000": "無効なパラメータです。",
+  "P01081001": "無効なパラメータです。",
+  "P01081002": "指定メソッドはサポートされていません。",
+  "P01081003": "メソッドが指定されていません。",
+  "P01081004": "リクエストパラメータが指定されていません。",
+  "P01081100": "パラメータが指定されていません。（Amt）",
+  "P01081101": "パラメータが指定されていません。（MaxAmt）",
+  "P01081102": "パラメータが指定されていません。（ReturnURL）",
+  "P01081103": "パラメータが指定されていません。（NotifyURL）",
+  "P01081104": "パラメータが指定されていません。（CancelURL）",
+  "P01081105": "パラメータが指定されていません。（ShipToStreet）",
+  "P01081106": "パラメータが指定されていません。（ShipToStreet2）",
+  "P01081107": "パラメータが指定されていません。（ShipToCity）",
+  "P01081108": "パラメータが指定されていません。（ShipToState）",
+  "P01081109": "パラメータが指定されていません。（ShipToZip）",
+  "P01081110": "パラメータが指定されていません。（Country）",
+  "P01081111": "パラメータが指定されていません。（ReqConfirmShipping）",
+  "P01081112": "パラメータが指定されていません。（NoShipping）",
+  "P01081113": "パラメータが指定されていません。（AddrOverride）",
+  "P01081114": "パラメータが指定されていません。（LocaleCode）",
+  "P01081115": "パラメータが指定されていません。（PaymentAction）",
+  "P01081116": "パラメータが指定されていません。（Email）",
+  "P01081117": "パラメータが指定されていません。（Token）",
+  "P01081118": "パラメータが指定されていません。（PayerID）",
+  "P01081119": "パラメータが指定されていません。（ItemAmt）",
+  "P01081120": "パラメータが指定されていません。（ShippingAmt）",
+  "P01081121": "パラメータが指定されていません。（HandlingAmt）",
+  "P01081122": "パラメータが指定されていません。（TaxAmt）",
+  "P01081123": "パラメータが指定されていません。（IPAddress）",
+  "P01081124": "パラメータが指定されていません。（ShipToName）",
+  "P01081125": "パラメータが指定されていません。（L_Amt）",
+  "P01081126": "パラメータが指定されていません。（Amt）",
+  "P01081127": "パラメータが指定されていません。（L_TaxAmt）",
+  "P01081128": "パラメータが指定されていません。（AuthorizationID）",
+  "P01081129": "パラメータが指定されていません。（CompleteType）",
+  "P01081130": "パラメータが指定されていません。（CurrencyCode）",
+  "P01081131": "パラメータが指定されていません。（TransactionID）",
+  "P01081132": "パラメータが指定されていません。（TransactionEntity）",
+  "P01081133": "パラメータが指定されていません。（Acct）",
+  "P01081134": "パラメータが指定されていません。（ExpDate）",
+  "P01081135": "パラメータが指定されていません。（FirstName）",
+  "P01081136": "パラメータが指定されていません。（LastName）",
+  "P01081137": "パラメータが指定されていません。（Street）",
+  "P01081138": "パラメータが指定されていません。（Street2）",
+  "P01081139": "パラメータが指定されていません。（City）",
+  "P01081140": "パラメータが指定されていません。（State）",
+  "P01081141": "パラメータが指定されていません。（Zip）",
+  "P01081142": "パラメータが指定されていません。（CountryCode）",
+  "P01081143": "パラメータが指定されていません。（RefundType）",
+  "P01081144": "パラメータが指定されていません。（StartDate）",
+  "P01081145": "パラメータが指定されていません。（EndDate）",
+  "P01081146": "パラメータが指定されていません。（MPID）",
+  "P01081147": "パラメータが指定されていません。（CreditCardType）",
+  "P01081148": "パラメータが指定されていません。（User）",
+  "P01081149": "パラメータが指定されていません。（Pwd）",
+  "P01081150": "パラメータが指定されていません。（Version）",
+  "P01081200": "無効なパラメータです。（Amt）",
+  "P01081201": "無効なパラメータです。（MaxAmt）",
+  "P01081203": "無効なパラメータです。（NotifyURL）",
+  "P01081205": "無効なパラメータです。（ShipToStreet）",
+  "P01081206": "無効なパラメータです。（ShipToStreet2）",
+  "P01081207": "無効なパラメータです。（ShipToCity）",
+  "P01081208": "無効なパラメータです。（ShipToState）",
+  "P01081209": "無効なパラメータです。（ShipToZip）",
+  "P01081210": "無効なパラメータです。（Country）",
+  "P01081211": "無効なパラメータです。（ReqConfirmShipping）",
+  "P01081212": "無効なパラメータです。（Noshipping）",
+  "P01081213": "無効なパラメータです。（AddrOverride）",
+  "P01081214": "無効なパラメータです。（LocaleCode）",
+  "P01081215": "無効なパラメータです。（PaymentAction）",
+  "P01081219": "無効なパラメータです。（ItemAmt）",
+  "P01081220": "無効なパラメータです。（ShippingAmt）",
+  "P01081221": "無効なパラメータです。（HandlingTotal Amt）",
+  "P01081222": "無効なパラメータです。（TaxAmt）",
+  "P01081223": "無効なパラメータです。（IPAddress）",
+  "P01081224": "無効なパラメータです。（ShipToName）",
+  "P01081225": "無効なパラメータです。（L_Amt）",
+  "P01081226": "無効なパラメータです。（Amt）",
+  "P01081227": "無効なパラメータです。（L_TaxAmt）",
+  "P01081229": "無効なパラメータです。（CompleteType）",
+  "P01081230": "無効なパラメータです。（CurrencyCode）",
+  "P01081232": "無効なパラメータです。（TransactionEntity）",
+  "P01081234": "無効なパラメータです。（ExpDate）",
+  "P01081235": "無効なパラメータです。（FirstName）",
+  "P01081236": "無効なパラメータです。（LastName）",
+  "P01081237": "無効なパラメータです。（Street）",
+  "P01081238": "無効なパラメータです。（Street2）",
+  "P01081239": "無効なパラメータです。（City）",
+  "P01081243": "無効なパラメータです。（RefundType）",
+  "P01081244": "無効なパラメータです。（StartDate）",
+  "P01081245": "無効なパラメータです。（EndDate）",
+  "P01081247": "無効なパラメータです。（CreditCardType）",
+  "P01081248": "無効なパラメータです。（Username）",
+  "P01081249": "無効なパラメータです。（Password）",
+  "P01081250": "無効なパラメータです。（Version）",
+  "P01081251": "内部エラーが発生しました。",
+  "P02000001": "PayPalセンターとの通信に失敗しました。",
+  "P02000002": "PayPalセンターとの通信に失敗しました。",
+  "P03000003": "PayPalの支払操作をユーザがキャンセルしました。",
+  "PD1000001": "Paidに取引が存在しません。",
+  "PD1000002": "Paidからエラーコード（呼出しパラメータ不正）が返却されました。",
+  "PD1000003": "Paid側でエラーが発生しました。",
+  "PD1000004": "リクエスト件数の上限を超過しました。",
+  "PD1000005": "Paidから想定外のステータスが返却されました。",
+  "PD1000006": "指定した取引先は利用不可です。",
+  "PD1000007": "指定した取引先は限度額オーバーです。",
+  "PD1000009": "Paidからエラーコード（パラメータ不正）が返却されました。",
+  "PD1000010": "Paidからエラーコード（パラメータ内容不備）が返却されました。",
+  "PD1000011": "Paidからエラーコード（ Paid取引先ID登録済み）が返却されました。",
+  "PD1000012": "指定した Paid取引先IDが存在しません。",
+  "PD1000013": "Paidからエラーコード（その他）が返却されました。",
+  "PD1000014": "指定した取引先は登録済みです。",
+  "RC1000001": "状態遷移チェックエラー(不正な遷移)",
+  "RC1000002": "状態遷移チェックエラー(期限切れ)",
+  "RC1000003": "状態遷移チェックエラー(決済済み)",
+  "RC1000005": "取引IDチェックエラー",
+  "RC1000006": "取引存在チェックエラー",
+  "RC1000007": "リクエスト改ざんチェックエラー",
+  "RC1000008": "リクルートかんたん支払い終了受付:状態遷移エラー",
+  "RC1000009": "決済失敗エラー",
+  "RC1000101": "リクエストパラメータ異常後続決済センターで、リクエストパラメータが仕様と異なる場吅に返却されます。",
+  "RC1000109": "処理対象ステータスエラー後続決済センターで、ステータスが処理対象でない場吅に発生します。",
+  "RC1000110": "返金処理に失敗しました。後続決済センターで、決済金額より返金する金額が大きいか、返金対象期間を過ぎてしまっている場吅に発生します。",
+  "RC1000111": "ポイント全額決済エラーポイント全額決済のため、後続決済センターが処理を受け付けられない場吅に発生します。",
+  "RC1000112": "クレジットカードエラークレジットカードの与信取得に失敗した場吅に発生します。",
+  "RC2000001": "リクルートかんたん支払い決済結果受信ステータスチェックエラー",
+  "RC2000002": "リクルート通信エラー",
+  "RC2000009": "リクルートかんたん支払い決済結果受信入力パラメータエラー",
+  "RC2000010": "リクルートかんたん支払い決済結果受信取引存在チェックエラー",
+  "RC2000102": "APIサーバ例外後続決済センターの内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
+  "RC2000103": "データ無しエラー後続決済センターでリクエストパラメータと一致するデータが存在しない場吅に発生します。",
+  "RC2000104": "メンテナンス中後続決済センターでメンテナンス中であり、処理を受け付けられない場吅に発生します。",
+  "RC2000105": "実行権限エラー APIを実行する権限がないため、APIが処理を受け付けることができない場吅に発生します。",
+  "RC2000106": "ショップIDチェックエラー後続決済センターに存在しないショップIDを受け付けた場吅に発生します。",
+  "RC2000107": "吅計金額範囲外エラー後続決済センターで吅計金額が有効桁数を超えた場吅に発生します。",
+  "RC2000108": "オーダーIDチェックエラー後続決済センターに存在しないオーダーIDを受け付けた場吅に発生します。",
+  "RC2009999": "その他システムエラー",
+  "RC3000001": "状態遷移チェックエラー(不正な遷移)",
+  "RC3000002": "状態遷移チェックエラー(期限切れ)",
+  "RC3000003": "状態遷移チェックエラー(決済済み)",
+  "RC3000005": "取引IDチェックエラー",
+  "RC3000006": "取引存在チェックエラー",
+  "RC3000007": "リクエスト改ざんチェックエラー",
+  "RC3000008": "リクルートかんたん支払い継続課金終了受付:状態遷移エラー",
+  "RC3000009": "決済失敗エラー",
+  "RC3000110": "処理対象ステータスエラー後続決済センターで、ステータスが処理対象でない場吅に発生します。",
+  "RC3000111": "返金処理に失敗しました。後続決済センターで、決済金額より返金する金額が大きいか、返金対象期間を過ぎてしまっている場吅に発生します。",
+  "RC3000112": "処理不可エラー後続決済センターで、購入者がブラックリストに入っている等、処理を受付けることができない場吅に発生します。",
+  "RC3000113": "継続課金失敗エラー後続決済センターで、継続課金に失敗した場吅に発生します。",
+  "RC3000114": "継続課金失敗強制解約後続決済センターで、継続課金に失敗し強制解約した場吅に発生します。",
+  "RC3000115": "解約済みのため継続課金に失敗しました。",
+  "RC4000001": "リクルートかんたん支払い継続課金結果受信ステータスチェックエラー",
+  "RC4000002": "リクルート通信エラー",
+  "RC4000003": "リクルートかんたん継続課金実売上エラー",
+  "RC4000004": "リクルートかんたん継続課金実売上失敗後取消エラー",
+  "RC4000010": "リクルートかんたん継続課金結果受信取引存在チェックエラー",
+  "RC4000101": "リクエストパラメータ異常後続決済センターで、リクエストパラメータが仕様と異なる場吅に返却されます。",
+  "RC4000102": "APIサーバ例外後続決済センターの内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
+  "RC4000103": "データ無しエラー後続決済センターでリクエストパラメータと一致するデータが存在しない場吅に発生します。",
+  "RC4000104": "メンテナンス中後続決済センターでメンテナンス中であり、処理を受け付けられない場吅に発生します。",
+  "RC4000105": "実行権限エラー APIを実行する権限がないため、APIが処理を受け付けることができない場吅に発生します。",
+  "RC4000106": "マーチャントIDチェックエラー後続決済センターに存在しないマーチャントIDを受け付けた場吅に発生します。",
+  "RC4000107": "商品IDチェックエラー後続決済センターに存在しない商品 IDを受け付けた場吅に発生します。",
+  "RC4000108": "商品金額チェックエラー後続決済センターに存在しない商品金額を受け付けた場吅に発生します。",
+  "RC4000109": "注文番号、契約番号チェックエラー後続決済センターに存在しない注文番号（契約番号）を受け付けた場吅に発生します。",
+  "RC4009999": "その他システムエラー",
+  "RI1000001": "状態遷移チェックエラー(不正な遷移)",
+  "RI1000002": "状態遷移チェックエラー(期限切れ)",
+  "RI1000003": "状態遷移チェックエラー(決済済み)",
+  "RI1000004": "購入情報なし",
+  "RI1000005": "取引IDチェックエラー",
+  "RI1000006": "取引の存在チェックエラー",
+  "RI1000007": "決済不整吅エラー",
+  "RI1000008": "状態遷移エラー",
+  "RI1000009": "システムエラー(※1)",
+  "RI1009999": "その他エラー",
+  "RI2000100": "システムエラー",
+  "S01000002": "メール作成失敗",
+  "S01001001": "認証情報不正",
+  "S01001002": "システム接続不可",
+  "S01001006": "データ不正",
+  "S01001007": "非会員、または退会済会員",
+  "S01001008": "登録可能件数オーバー",
+  "S01001010": "決済依頼ID重複",
+  "S01001012": "登録データなし",
+  "S01001015": "一時無効会員",
+  "S01001016": "XML形式不正",
+  "S01009901": "システムエラーモバイルSuicaシステムの内部エラー",
+  "S01009902": "システムメンテナンス中モバイルSuicaシステムがメンテナンス等で停止している場吅に通知されます",
+  "SB1000001": "【決済要求】後続決済センターで確定処理が失敗しました。",
+  "SB1000002": "【取消要求、決済中止】お宠様がソフトバンクまとめて支払い(Ｂ)を中止または取消し処理が失敗しました。",
+  "SB1000004": "【決済失敗】ソフトバンクまとめて支払い(Ｂ)が失敗しました。",
+  "SB1000005": "【決済要求】後続決済センターとの通信に失敗しました。",
+  "SC1000001": "月初における課金データの作成に失敗しました。",
+  "SC1000002": "課金日における課金データの確定に失敗しました。",
+  "SC1000003": "課金申込時の初回課金に失敗しました。",
+  "SC1000004": "取消返金要求失敗",
+  "SC1000005": "状態遷移チェックエラー(不正な遷移)",
+  "SC1000006": "状態遷移チェックエラー(期限切れ)",
+  "SC1000007": "状態遷移チェックエラー(登録済み)",
+  "SC1000008": "購入情報無し",
+  "SC1000009": "状態遷移チェックエラー(登録済み)",
+  "SC1000010": "状態遷移チェックエラー(不正な遷移)",
+  "SC1000011": "システムの内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
+  "SC1000012": "購入情報無し",
+  "SC1000013": "システムの内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
+  "SC1000014": "課金申込に失敗しました。",
+  "SC1000015": "ユーザ解約のため処理に失敗しました。",
+  "SC2000001": "月初における課金データの作成に失敗しました。",
+  "SC2000002": "課金日における課金データの確定に失敗しました。",
+  "SE1990001": "セブンイレブン・決済要求エラー/取引失敗を表示し、お問い吅わせ下さい。",
+  "SE1990002": "セブンイレブン・決済キャンセル要求エラー/取引失敗を表示し、お問い吅わせ下さい。",
+  "UP1000001": "状態遷移チェックエラー(不正な遷移)",
+  "UP1000002": "状態遷移チェックエラー(期限切れ)",
+  "UP1000003": "状態遷移チェックエラー(決済済み)",
+  "UP1000004": "受信エラー（通信電文異常）",
+  "UP1000005": "受信エラー（処理期限超過）",
+  "UP1008000": "銀聯エラー（要求失敗）実売上/返品/キャンセル要求に失敗しました。銀聯の内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
+  "UP1009900": "銀聯エラー（その他）銀聯の内部エラーです。発生時刻や呼び出しパラメータをご確認のうえ、お問い吅わせください。",
+  "W0100R156": "支払期限切れエラー",
+  "W0100W001": "データ種別不正",
+  "W0100W002": "UserId/Passwordが存在しない",
+  "W0100W003": "収納処理企業コード/支払いコードが一致しない",
+  "W0100W004": "2DBC処理஦業者番号/契約案件番号が一致しない",
+  "W0100W005": "入金処理企業コード/支払いコードが一致しない",
+  "W0100W090": "キーデータ取得時エラー",
+  "W0100W092": "短時間の要求過多によりアクセスが制限されました。／取引失敗を表示し、再度実行して下さい。",
+  "W0100W600": "収納処理項目チェック時エラー ( 不正な値 )",
+  "W0100W601": "収納処理項目チェック時エラー ( 支払いコード未設定 )",
+  "W0100W602": "収納処理項目チェック時エラー ( 支払いコード桁不足 )",
+  "W0100W603": "収納処理項目チェック時エラー ( 受付番号未設定 )",
+  "W0100W604": "収納処理項目チェック時エラー ( 受付番号桁不足 )",
+  "W0100W605": "収納処理項目チェック時エラー ( 企業コード未設定 )",
+  "W0100W606": "収納処理項目チェック時エラー ( 企業コード桁不足 )",
+  "W0100W607": "収納処理項目チェック時エラー ( 電話番号未設定 )",
+  "W0100W608": "収納処理項目チェック時エラー ( 漢字氏ྡ未設定 )",
+  "W0100W609": "収納処理項目チェック時エラー ( 支払期限未設定 )",
+  "W0100W610": "収納処理項目チェック時エラー ( 支払期限数字以外の値 )",
+  "W0100W611": "収納処理項目チェック時エラー ( 支払期限桁不正 )",
+  "W0100W612": "収納処理項目チェック時エラー ( 支払期限日時の値不正 )",
+  "W0100W613": "収納処理項目チェック時エラー ( 支払期限過去日付不正 )",
+  "W0100W614": "収納処理項目チェック時エラー ( 支払金額未設定 )",
+  "W0100W615": "収納処理項目チェック時エラー ( 支払金額値不正 )",
+  "W0100W616": "収納処理項目チェック時エラー ( 支払金額 ≦0 )",
+  "W0100W617": "収納処理項目チェック時エラー ( 支払金額＞ 999999 )",
+  "W0100W640": "収納情報重複エラー",
+  "W0100W641": "収納情報論理削除済みエラー",
+  "W0100W642": "収納処理削除(D) 収納情報なしエラー",
+  "W0100W643": "収納処理削除(D) 収納情報論理削除済エラー",
+  "W0100W644": "収納処理削除収納情報変更不可エラー",
+  "W0100W670": "収納DB OPEN時エラー",
+  "W0100W671": "収納DB READ時エラー",
+  "W0100W672": "収納DB INSERT時エラー",
+  "W0100W673": "収納処理削除(D) 収納DB Open時エラー",
+  "W0100W674": "収納処理削除(D) 収納DB Read時エラー",
+  "W0100W675": "収納処理削除(D) 収納DB Insert時エラー",
+  "W0100W680": "ケータイ決済番号用シーケンスN oを取得できない",
+  "W0100W691": "収納処理削除(D)該当の収納データは照会中のため削除できません",
+  "W0100W700": "入金処理項目チェックエラー（支払コード未設定）",
+  "W0100W701": "入金処理項目チェックエラー（企業コード未設定）",
+  "W0100W730": "入金処理未入金エラー",
+  "W0100W731": "入金処理未送信データなしエラー",
+  "W0100W740": "入金処理入金情報なしエラー",
+  "W0100W741": "入金処理入金情報論理削除済みエラー",
+  "W0100W770": "入金処理 READ要求入金DB OPEN時エラー",
+  "W0100W771": "入金処理 READ要求入金DB READ時エラー",
+  "W0100W772": "入金処理 READ要求入金DBUPDATE時エラー",
+  "W0100W773": "入金処理 SEARCH要求入金D BOPEN時エラー",
+  "W0100W774": "入金処理 SEARCH要求入金D BREAD時エラー",
+  "W0100W775": "入金処理 SEARCH要求入金D BUPDATE時エラー",
+  "W0100W853": "コンビニ決済஦業者による内部エラー/お問い吅わせ下さい。",
+  "W02000001": "決済要求エラー/取引失敗を表示し、お問い吅わせ下さい。",
+  "W02000002": "支払い停止要求エラー/取引失敗を表示し、お問い吅わせ下さい。",
+  "W02000003": "加盟店設定エラー/取引失敗を表示し、お問い吅わせ下さい。",
+  "WM1000001": "【決済要求】後続決済センターとの通信パラメータでエラーが発生しました。（メッセージダイジェスト）",
+  "WM1000002": "【決済要求】後続決済センターで許可されていない接続です。",
+  "WM1000003": "【決済要求】後続決済センターで決済モジュールの実行に失敗しました。",
+  "WM1000004": "【決済要求】後続決済センターとの通信パラメータでエラーが発生しました。（受信パラメータ）",
+  "WM1000005": "【決済要求】後続決済センターとの通信に失敗しました。",
+  "WM1000006": "【決済結果受信】後続決済センターとの通信パラメータでエラーが発生しました。（受信パラメータ）",
+  "WM1000007": "【決済結果受信】後続決済センターで஧重入金が発生しました。",
+  "WM1000008": "【決済結果受信】内部エラーが発生しました。（遷移）",
+  "WM1000009": "【ユーザーキャンセル受信】入金済みの取引に対し、ユーザーの支払操作がキャンセルされた通知を受信しました。",
+  "WM1000010": "【ユーザーキャンセル受信】内部エラーが発生しました。（遷移）"
 }

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -13,14 +13,14 @@ test('variables is message as instance', (t) => {
 
 test('.parseError returns ErrInfo as array', (t) => {
   const err = new BadRequest().parseError({ErrInfo: 'NC1000009|N0C030G96'})
-  t.is(err.errors[0].en, 'Input parameter error / billing information presence judgment flag incorrect format')
-  t.is(err.errors[1].en, '[Settlement request] Cancel processing has failed at the subsequent settlement center.')
+  t.is(err.errors[0], '決済NG')
+  t.is(err.errors[1], 'カード会社にて受付を拒否しました。')
   t.is(err.errInfo[0], 'NC1000009')
   t.is(err.errInfo[1], 'N0C030G96')
 })
 
 test('.parseError returns unique ErrInfos', (t) => {
   const err = new BadRequest().parseError({ErrInfo: 'E61030001|E61030001'})
-  t.deepEqual(err.errors, [{ja: 'ご契約内容エラー/現在のご契約では、ご利用になれません。', en: 'Your request cannot be accepted under the current merchant contract.'}])
+  t.deepEqual(err.errors, ['加盟店設定エラー/決済を中止して、問い吅わせにて設定状況を確認して下さい。'])
   t.deepEqual(err.errInfo, ['E61030001'])
 })

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,12 +1,7 @@
-/**
- * Initial errors (total: 1688 https://github.com/pepabo/gmopg/blob/38d449841513096b40efbfc9c0a89dc8419e382f/src/errors.ts#L20) were added by user: linyows, with Japanese messages
- * We translated them to English with google-translate
- * The error ranges: E00000000-EX1000304, 42C010000-42G990000, M01330001-M01334011, AC2000001-AC2000004 (total: 283) were later added or updated by user: caub, with Japanese and English messages provided by gmo-pg engineers
- */
-const errorDefinition: {[key: string]: {ja: string, en: string}} = require('../error-codes.json');
+const errorDefinition: {[key: string]: string} = require('../error-codes.json');
 
 export class BadRequest extends Error {
-  public errors: {ja: string, en: string}[]
+  public errors: string[]
   public errInfo: string[]
   public response: any
 


### PR DESCRIPTION
The English translations in the current `error-codes.json` (from google-translate) are not really good, so let's revert to how it was initially, it's not really worth doubling the size

Here's a google sheet with English messages computed with google-translate for reference:
https://docs.google.com/spreadsheets/u/1/d/e/2PACX-1vTApl1UQhII8swczi81J5Hfz951p0GcPIwOkRwDnmCbt3Jsv-cFN7dkqZtQVsTtgfgWJl000CBqOY1W/pub