### PR TITLE
Add CVS result field on SearchTradeMulti API

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "qs": "^6.9.0"
   },
   "devDependencies": {
-    "@types/encoding-japanese": "^1.0.15",
+    "@types/encoding-japanese": "^1.0.17",
     "@types/nock": "^11.1.0",
     "@types/node": "^12.7.11",
     "@types/node-fetch": "^2.5.2",

--- a/src/client.type.ts
+++ b/src/client.type.ts
@@ -15,5 +15,5 @@ export type Result = {
 }
 
 export type UnknownParams = {
-  [key: string]: qs.UnknownFacade
+  [key: string]: unknown
 }

--- a/src/client/cardable.ts
+++ b/src/client/cardable.ts
@@ -82,20 +82,18 @@ export default <T extends Constructor<Client>>(Base: T) =>
       const errCodeArry: string[] = parsed.ErrCode?.split('|') || []
       const errInfoArry: string[] = parsed.ErrInfo?.split('|') || []
 
-      return cardNoArry.map(
-        (_, index): SearchCardDetailResult => {
-          return {
-            CardNo: cardNoArry[index],
-            Brand: brandArry[index],
-            DomesticFlag: domesticFlagArry[index],
-            IssuerCode: issuerCodeArry[index],
-            DebitPrepaidFlag: debitPrepaidFlagArry[index],
-            DebitPrepaidIssuerName: debitPrepaidIssuerNameArry[index],
-            ForwardFinal: forwardFianlArry[index],
-            ErrCode: errCodeArry[index],
-            ErrInfo: errInfoArry[index],
-          }
+      return cardNoArry.map((_, index): SearchCardDetailResult => {
+        return {
+          CardNo: cardNoArry[index],
+          Brand: brandArry[index],
+          DomesticFlag: domesticFlagArry[index],
+          IssuerCode: issuerCodeArry[index],
+          DebitPrepaidFlag: debitPrepaidFlagArry[index],
+          DebitPrepaidIssuerName: debitPrepaidIssuerNameArry[index],
+          ForwardFinal: forwardFianlArry[index],
+          ErrCode: errCodeArry[index],
+          ErrInfo: errInfoArry[index],
         }
-      )
+      })
     }
   }

--- a/src/client/cvsTranable.ts
+++ b/src/client/cvsTranable.ts
@@ -30,15 +30,15 @@ export default <T extends Constructor<Client>>(Base: T) =>
     public async execTranCvs(args: ExecTranCvsArgs): Promise<ExecTranCvsResult> {
       return this.post<ExecTranCvsArgs, ExecTranCvsResult>('/payment/ExecTranCvs.idPass', {
         ...args,
-        CustomerName: encoding.urlEncode(encoding.convert(args.CustomerName, 'SJIS')),
-        CustomerKana: encoding.urlEncode(encoding.convert(args.CustomerKana, 'SJIS')),
+        CustomerName: encoding.urlEncode(encoding.convert(args.CustomerName, { to: 'SJIS', type: 'array' })),
+        CustomerKana: encoding.urlEncode(encoding.convert(args.CustomerKana, { to: 'SJIS', type: 'array' })),
       })
     }
 
     public async cancelCvs(args: CancelCvsArgs): Promise<CancelCvsResult> {
       const defaultData = {
-        ShopID: this.config?.ShopID,
-        ShopPass: this.config?.ShopPass,
+        ShopID: this.config.ShopID,
+        ShopPass: this.config.ShopPass,
         AccessID: undefined,
         AccessPass: undefined,
         OrderID: undefined,

--- a/src/client/multiTranable.test.ts
+++ b/src/client/multiTranable.test.ts
@@ -29,6 +29,7 @@ test('.searchTradeMulti calls API and returns response - CVS', async t => {
     CvsConfNo: 'cvsconfno',
     CvsReceiptNo: 'cvsreceiptno',
     PaymentTerm: 'paymentterm',
+    FinishDate: 'finishdate',
   }
 
   sinon.stub(multiTranable, 'post').resolves(expect)

--- a/src/client/multiTranable.type.ts
+++ b/src/client/multiTranable.type.ts
@@ -46,4 +46,5 @@ export type SearchTradeMultiCvsResult = Result & {
   CvsConfNo: string
   CvsReceiptNo: string
   PaymentTerm: string
+  FinishDate: string
 }


### PR DESCRIPTION
1. There was updating on CVS result field on SearchTradeMulti API on Dec 2020, so I added `FinishDate` field.
```
拝啓  貴社ますますご清栄のこととお慶び申しあげます。
PGマルチペイメントサービスをご利用いただきまして、
誠にありがとうございます。
2020年12月15日に予定しておりました下記の取引状態参照APIの仕様変更で
ございますが、日時を変更し、2020年12月22日に実施させていただくことに
なりました。
お客様におかれましては、ご面倒をお掛けいたしますが
何卒ご理解を賜りますようお願い申しあげます。
                                                                 敬 具
                                  記                                 
1.影響範囲
  1-1.決済手段
    PGマルチペイメント　全決済手段
  1-2.接続タイプ
    モジュールおよびプロトコルタイプでご利用の場合。
    ※以下に該当する場合、当変更の影響はございません。
      ・リンクタイプ、リンクタイプPlusをご利用の場合
      ・EC-CUBEをご利用の場合
        （他ショッピングカートご利用の場合、カート提供元にご確認ください。）
2.仕様変更内容
  2-1.対象API名
    取引状態参照API：SearchTradeMulti
  2-2.変更内容
    ・不要パラメータ削除
      APIの応答として、ご指定いただいた決済手段のパラメータ名以外も
      返却しておりましたが、ご指定いただいた決済手段のパラメータのみ
      返却し、他決済手段のパラメータ名を返却しないよう変更いたします。
    ・コンビニ決済【入金確定日】を追加
      コンビニ決済で、コンビニ店舗でご利用者様が入金された日付を
      追加いたします。
      パラメータ名：FinishDate（YYYYMMDD形式で返却します）
  参考資料.コンビニ決済を例とした資料は以下リンクをご参照ください。
  https://willap.jp/file/AAACrHnMPf3mj_jxnH2sYMH2LnVowAwcVdSuKg
    お取引の決済手段により、返却パラメータが変わります。
    返却されるパラメータについては、以下のドキュメントを
    ご参照ください。
    管理画面
      ->ドキュメント
        ->ドキュメント一覧
          ->プロトコルタイプ
            ->プロトコルタイプ(マルチ決済インタフェース仕様)
              ->30.1.2.1. 取引状態参照
          ->モジュールタイプタイプ
            ->モジュールタイプ(Java版_マルチ決済インタフェース仕様)
            ->モジュールタイプ(PHP版_マルチ決済インタフェース仕様)
              ->28.1.2.1. 取引状態参照
3.適用日
    テスト環境：変更済み
    本番環境  ：2020年12月22日（火） AM 7:00 - AM 9:00
    ※上記時間に変更いたします。
      当変更にともなうサービス停止はございません。
※ご留意点
  モジュールタイプをご利用で【入金確定日】を取得されたい場合、
  上記適用日以降、各環境より最新モジュールをダウンロードください。
  （上記パラメータ取得が不要な場合、モジュールの差し替えは不要です。）
4.本件に関する問合せ先
      GMOペイメントゲートウェイ株式会社 ／ カスタマーサポートセンター
      電子メール ： support@gmo-pg.com
      電話番号   ： 03-3464-2346（平日10:00-17:00）
      ※音声ガイダンスが流れますので "4" をお選びください
```
![SearchTradeMulti_コンビニ決済例](https://user-images.githubusercontent.com/20296460/118453516-46435e00-b732-11eb-9351-e40a8ad3f2f3.png)

2. I fixed some typing errors.
- typing error on using code `encoding-japanese`.
- `qs.UnknownFacade` to `unknown` because there is no `UnknownFacade` exported on `querystring` module.